### PR TITLE
Update CampaignBudget and Campaign Types

### DIFF
--- a/src/types/Campaign.ts
+++ b/src/types/Campaign.ts
@@ -191,7 +191,6 @@ declare namespace Campaign {
      */
     export interface NewCampaignConfig extends NewEntityConfig {
         budget_id: string
-        name: string
         advertising_channel_type: AdvertisingChannelType | keyof typeof AdvertisingChannelType
         target_spend?: TargetSpend
         status?: CampaignStatus

--- a/src/types/Campaign.ts
+++ b/src/types/Campaign.ts
@@ -111,15 +111,6 @@ declare namespace Campaign {
         VIDEO_ACTION = 'VIDEO_ACTION',
         VIDEO_OUTSTREAM = 'VIDEO_OUTSTREAM'
     }
-    
-    /**
-     * Enum for PageOnePromotedStrategyGoal
-     * @readonly
-     * @enum {string}
-     */
-    enum PageOnePromotedStrategyGoal {
-        UNSPEC 
-    }
 
     /**
      * Interface for NetworkSettings
@@ -138,68 +129,60 @@ declare namespace Campaign {
      */
     export interface TargetSpend {
         cpc_bid_ceiling_micros: string | number
+        target_spend_micros?: string | number
     }
     
     /**
-     * Interface for ManualCpcBiddingStrategy
+     * Interface for ManualCpc
      * @interface
      */
-    export interface ManualCpcBiddingStrategy {
+    export interface ManualCpcy {
         enhanced_cpc_enabled: boolean
     }
     
     /**
-     * Interface for ManualCpcBiddingStrategy
+     * Interface for ManualCpc
      * @interface
      */
-    export interface ManualCpcBiddingStrategy {
+    export interface ManualCpc {
         enhanced_cpc_enabled: boolean
     }
     
     /**
-     * Interface for MaximizeConversionValueBiddingStrategy
+     * Interface for MaximizeConversionValue
      * @interface
      */
-    export interface MaximizeConversionValueBiddingStrategy {
+    export interface MaximizeConversionValue {
         target_roas: string | number
     }
     
     /**
-     * Interface for PercentCpcBiddingStrategy
+     * Interface for PercentCpc
      * @interface
      */
-    export interface PercentCpcBiddingStrategy {
+    export interface PercentCpc {
         cpc_bid_ceiling_micros?: string | number
         enhanced_cpc_enabled?: boolean
     }
     
     /**
-     * Interface for TargetCpaBiddingStrategy
+     * Interface for TargetCpa
      * @interface
      */
-    export interface TargetCpaBiddingStrategy {
+    export interface TargetCpa {
         target_cpa_micros?: string | number
         cpc_bid_ceiling_micros?: string | number
         cpc_bid_floor_micros?: string | number
     }
     
     /**
-     * Interface for TargetRoasBiddingStrategy
+     * Interface for TargetRoas
      * @interface
      */
-    export interface TargetRoasBiddingStrategy {
+    export interface TargetRoas {
         target_cpa_micros?: string | number
         cpc_bid_ceiling_micros?: string | number
         cpc_bid_floor_micros?: string | number
-    }
-    
-    /**
-     * Interface for TargetSpendBiddingStrategy
-     * @interface
-     */
-    export interface TargetSpendBiddingStrategy {
-        target_spend_micros?: string | number
-        cpc_bid_ceiling_micros?: string | number
     }
 
     /**
@@ -214,16 +197,16 @@ declare namespace Campaign {
         status?: CampaignStatus
         network_setting?: NetworkSettings
         advertising_channel_sub_type?: AdvertisingChannelSubType | keyof typeof AdvertisingChannelSubType
-        manual_cpc?: ManualCpcBiddingStrategy
+        manual_cpc?: ManualCpc
         // manual_cpm?: any
         // manual_cpv?: any
-        maximize_conversion_value?: MaximizeConversionValueBiddingStrategy
+        maximize_conversion_value?: MaximizeConversionValue
         // maximize_conversions?: any
-        percent_cpc?: PercentCpcBiddingStrategy
-        target_cpa?: TargetCpaBiddingStrategy
+        percent_cpc?: PercentCpc
+        target_cpa?: TargetCpa
         // target_cpm?: any
-        target_roas?: TargetRoasBiddingStrategy
-        target_spend?: TargetSpendBiddingStrategy
+        target_roas?: TargetRoas
+        target_spend?: TargetSpend
     }
 }
 export = Campaign

--- a/src/types/Campaign.ts
+++ b/src/types/Campaign.ts
@@ -90,6 +90,35 @@ declare namespace Campaign {
         SHOPPING = 'SHOPPING',
         UNKNOWN = 'UNKNOWN',
         UNSPECIFIED = 'UNSPECIFIED',
+        VIDEO = 'VIDEO',
+    }
+    
+    /**
+     * Enum for AdvertisingChannelSubType
+     * @readonly
+     * @enum {string}
+     */
+    enum AdvertisingChannelSubType {
+        DISPLAY_EXPRESS = 'DISPLAY_EXPRESS',
+        DISPLAY_GMAIL_AD = 'DISPLAY_GMAIL_AD',
+        DISPLAY_MOBILE_APP = 'DISPLAY_MOBILE_APP',
+        DISPLAY_SMART_CAMPAIGN = 'DISPLAY_SMART_CAMPAIGN',
+        SEARCH_EXPRESS = 'SEARCH_EXPRESS',
+        SEARCH_MOBILE_APP = 'SEARCH_MOBILE_APP',
+        SHOPPING_SMART_ADS = 'SHOPPING_SMART_ADS',
+        UNKNOWN = 'UNKNOWN',
+        UNSPECIFIED = 'UNSPECIFIED',
+        VIDEO_ACTION = 'VIDEO_ACTION',
+        VIDEO_OUTSTREAM = 'VIDEO_OUTSTREAM'
+    }
+    
+    /**
+     * Enum for PageOnePromotedStrategyGoal
+     * @readonly
+     * @enum {string}
+     */
+    enum PageOnePromotedStrategyGoal {
+        UNSPEC 
     }
 
     /**
@@ -110,6 +139,68 @@ declare namespace Campaign {
     export interface TargetSpend {
         cpc_bid_ceiling_micros: string | number
     }
+    
+    /**
+     * Interface for ManualCpcBiddingStrategy
+     * @interface
+     */
+    export interface ManualCpcBiddingStrategy {
+        enhanced_cpc_enabled: boolean
+    }
+    
+    /**
+     * Interface for ManualCpcBiddingStrategy
+     * @interface
+     */
+    export interface ManualCpcBiddingStrategy {
+        enhanced_cpc_enabled: boolean
+    }
+    
+    /**
+     * Interface for MaximizeConversionValueBiddingStrategy
+     * @interface
+     */
+    export interface MaximizeConversionValueBiddingStrategy {
+        target_roas: string | number
+    }
+    
+    /**
+     * Interface for PercentCpcBiddingStrategy
+     * @interface
+     */
+    export interface PercentCpcBiddingStrategy {
+        cpc_bid_ceiling_micros?: string | number
+        enhanced_cpc_enabled?: boolean
+    }
+    
+    /**
+     * Interface for TargetCpaBiddingStrategy
+     * @interface
+     */
+    export interface TargetCpaBiddingStrategy {
+        target_cpa_micros?: string | number
+        cpc_bid_ceiling_micros?: string | number
+        cpc_bid_floor_micros?: string | number
+    }
+    
+    /**
+     * Interface for TargetRoasBiddingStrategy
+     * @interface
+     */
+    export interface TargetRoasBiddingStrategy {
+        target_cpa_micros?: string | number
+        cpc_bid_ceiling_micros?: string | number
+        cpc_bid_floor_micros?: string | number
+    }
+    
+    /**
+     * Interface for TargetSpendBiddingStrategy
+     * @interface
+     */
+    export interface TargetSpendBiddingStrategy {
+        target_spend_micros?: string | number
+        cpc_bid_ceiling_micros?: string | number
+    }
 
     /**
      * Interface for NewCampaignConfig
@@ -117,8 +208,22 @@ declare namespace Campaign {
      */
     export interface NewCampaignConfig extends NewEntityConfig {
         budget_id: string
+        name: string
         advertising_channel_type: AdvertisingChannelType | keyof typeof AdvertisingChannelType
-        target_spend: TargetSpend
+        target_spend?: TargetSpend
+        status?: CampaignStatus
+        network_setting?: NetworkSettings
+        advertising_channel_sub_type?: AdvertisingChannelSubType | keyof typeof AdvertisingChannelSubType
+        manual_cpc?: ManualCpcBiddingStrategy
+        // manual_cpm?: any
+        // manual_cpv?: any
+        maximize_conversion_value?: MaximizeConversionValueBiddingStrategy
+        // maximize_conversions?: any
+        percent_cpc?: PercentCpcBiddingStrategy
+        target_cpa?: TargetCpaBiddingStrategy
+        // target_cpm?: any
+        target_roas?: TargetRoasBiddingStrategy
+        target_spend?: TargetSpendBiddingStrategy
     }
 }
 export = Campaign

--- a/src/types/CampaignBudget.ts
+++ b/src/types/CampaignBudget.ts
@@ -38,6 +38,19 @@ declare namespace CampaignBudget {
         PAUSED = 'PAUSED',
         UNSPECIFIED = 'UNSPECIFIED',
     }
+    
+    /**
+     * Enum for BudgetPeriod
+     * @readonly
+     * @enum {string}
+     */
+    enum BudgetPeriod {
+        CUSTOM = 'CUSTOM',
+        DAILY = 'DAILY',
+        FIXED_DAILY = 'FIXED_DAILY',
+        UNKNOWN = 'UNKNOWN',
+        UNSPECIFIED = 'UNSPECIFIED',
+    }
 
     /**
      * Interface for NewCampaignBudgetConfig
@@ -46,6 +59,8 @@ declare namespace CampaignBudget {
     export interface NewCampaignBudgetConfig extends NewEntityConfig {
         amount_micros: string | number
         explicitly_shared: boolean
+        delivery_method?: DeliveryMethod
+        period?: BudgetPeriod
     }
 }
 export = CampaignBudget


### PR DESCRIPTION
While testing the library it came up that some optional fields were missing from `NewCampaignBudgetConfig` and `NewCampaignConfig`

Some of the fields for `NewCampaignConfig` are mutually exclusive (e.g. `manual_cpc` and `target_spend` can't exist in the same call) so I'm not sure how you want to handle that. One potential solution could be to do something like this:

```typescript
type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
  T,
  Exclude<keyof T, Keys>
> &
  {
    [K in Keys]-?: Required<Pick<T, K>> &
      Partial<Record<Exclude<Keys, K>, undefined>>
  }[Keys];

interface BaseNewCampaignConfig extends NewEntityConfig {
  ...
}
export type NewCampaignConfig = RequireOnlyOne<BaseNewCampaignConfig, 'manual_cpc', 'manual_cpm'>
```

But there are more entities that have the same situation so I wanted to get input before making any more pull requests.