### PR TITLE
add update, conversionActions, and geoTargetConstants methods to Customer

### DIFF
--- a/src/Customer.ts
+++ b/src/Customer.ts
@@ -10,6 +10,7 @@ import AdGroupCriterions from './entities/AdGroupCriterions'
 import Keywords from './entities/Keywords'
 import SharedSets from './entities/SharedSets'
 import SharedSetCriterions from './entities/SharedSetCriterions'
+import ConversionActions from './entities/ConversionActions'
 
 import { ENDPOINTS, RESOURCE_NAMES } from './constants'
 import { Customer } from './types/Customer'
@@ -34,6 +35,7 @@ export default function Customer(http_controller: HttpController): Customer {
         keywords: new Keywords(http_controller),
         sharedSets: new SharedSets(http_controller),
         sharedSetCriterions: new SharedSetCriterions(http_controller),
+        conversionActions: new ConversionActions(http_controller),
         update: (config: UpdateConfig) => http_controller.update(config, 'mutateCustomer'),
         retrieve: () => http_controller.retrieve(ENDPOINTS.customers),
         query: (query: string) => http_controller.query(query),

--- a/src/Customer.ts
+++ b/src/Customer.ts
@@ -11,6 +11,7 @@ import Keywords from './entities/Keywords'
 import SharedSets from './entities/SharedSets'
 import SharedSetCriterions from './entities/SharedSetCriterions'
 import ConversionActions from './entities/ConversionActions'
+import GeoTargetConstants from './entities/GeoTargetConstants'
 
 import { ENDPOINTS, RESOURCE_NAMES } from './constants'
 import { Customer } from './types/Customer'
@@ -36,6 +37,11 @@ export default function Customer(http_controller: HttpController): Customer {
         sharedSets: new SharedSets(http_controller),
         sharedSetCriterions: new SharedSetCriterions(http_controller),
         conversionActions: new ConversionActions(http_controller),
+        geoTargetConstants: new GeoTargetConstants(
+            http_controller,
+            ENDPOINTS.geo_target_constants,
+            RESOURCE_NAMES.geo_target_constant
+        ),
         update: (config: UpdateConfig) => http_controller.update(config, 'mutateCustomer'),
         retrieve: () => http_controller.retrieve(ENDPOINTS.customers),
         query: (query: string) => http_controller.query(query),

--- a/src/Customer.ts
+++ b/src/Customer.ts
@@ -14,7 +14,7 @@ import SharedSetCriterions from './entities/SharedSetCriterions'
 import { ENDPOINTS, RESOURCE_NAMES } from './constants'
 import { Customer } from './types/Customer'
 import { HttpController } from './types/Http'
-import { ReportConfig } from './types/Global'
+import { ReportConfig, UpdateConfig } from './types/Global'
 
 export default function Customer(http_controller: HttpController): Customer {
     return {
@@ -34,6 +34,7 @@ export default function Customer(http_controller: HttpController): Customer {
         keywords: new Keywords(http_controller),
         sharedSets: new SharedSets(http_controller),
         sharedSetCriterions: new SharedSetCriterions(http_controller),
+        update: (config: UpdateConfig) => http_controller.update(config, 'mutateCustomer'),
         retrieve: () => http_controller.retrieve(ENDPOINTS.customers),
         query: (query: string) => http_controller.query(query),
         report: (config: ReportConfig) => http_controller.report(config),

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -162,6 +162,13 @@ export default class Http implements HttpController {
                 return update_operation
             })
             options.body = JSON.stringify({ operations })
+        } else if (entity && entity === 'mutateCustomer') {
+            const update_operation = {
+                update: config.update,
+                update_mask: getUpdateMask(config.update),
+            }
+            update_operation.update.resource_name = this.buildResourceName(entity, config.id)
+            options.body = JSON.stringify({ operation: update_operation })
         } else {
             const update_operation = {
                 update: config.update,
@@ -385,6 +392,9 @@ export default class Http implements HttpController {
     private getRequestUrl(operation_type?: string, endpoint?: string, entity_id?: string): string {
         if (endpoint && endpoint.includes('customers')) {
             return `${ADWORDS_API_BASE_URL}${this.client.cid}`
+        }
+        if (endpoint && endpoint === 'mutateCustomer') {
+            return `${ADWORDS_API_BASE_URL}${this.client.cid}:mutate`
         }
         if (operation_type && operation_type.includes('get')) {
             return `${ADWORDS_API_BASE_URL}${this.client.cid}/${endpoint}/${entity_id}`

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -208,6 +208,14 @@ export default class Http implements HttpController {
         return raw_result
     }
 
+    public async suggest(config: any, entity: string) {
+        await this.client.account_promise
+        const url = this.getRequestUrl('suggest', entity)
+        const options = await this.getRequestOptions('POST', url)
+        options.body = JSON.stringify(config)
+        return this.queryWithRetry(options)
+    }
+
     /*
      *   PRIVATE METHODS
      */
@@ -391,18 +399,23 @@ export default class Http implements HttpController {
 
     private getRequestUrl(operation_type?: string, endpoint?: string, entity_id?: string): string {
         if (endpoint && endpoint.includes('customers')) {
-            return `${ADWORDS_API_BASE_URL}${this.client.cid}`
+            return `${ADWORDS_API_BASE_URL}customers/${this.client.cid}`
         }
         if (endpoint && endpoint === 'mutateCustomer') {
-            return `${ADWORDS_API_BASE_URL}${this.client.cid}:mutate`
+            return `${ADWORDS_API_BASE_URL}customers/${this.client.cid}:mutate`
+        }
+        if (endpoint && endpoint === 'geoTargetConstants') {
+            return entity_id
+                ? `${ADWORDS_API_BASE_URL}${endpoint}/${entity_id}`
+                : `${ADWORDS_API_BASE_URL}${endpoint}:suggest`
         }
         if (operation_type && operation_type.includes('get')) {
-            return `${ADWORDS_API_BASE_URL}${this.client.cid}/${endpoint}/${entity_id}`
+            return `${ADWORDS_API_BASE_URL}customers/${this.client.cid}/${endpoint}/${entity_id}`
         }
         if (operation_type && operation_type.includes('mutate')) {
-            return `${ADWORDS_API_BASE_URL}${this.client.cid}/${endpoint}:mutate`
+            return `${ADWORDS_API_BASE_URL}customers/${this.client.cid}/${endpoint}:mutate`
         }
-        return `${ADWORDS_API_BASE_URL}${this.client.cid}/googleAds:search`
+        return `${ADWORDS_API_BASE_URL}customers/${this.client.cid}/googleAds:search`
     }
 
     private buildResourceName(endpoint?: string, entity_id?: string | number): string {

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -208,6 +208,22 @@ const entities: { [key: string]: object } = {
     shared_criterion: {
         type: '',
     },
+    conversion_action: {
+        app_id: '',
+        category: '',
+        click_through_lookback_window_days: '',
+        counting_type: '',
+        id: '',
+        include_in_conversions_metric: '',
+        name: '',
+        owner_customer: '',
+        phone_call_duration_seconds: '',
+        resource_name: '',
+        status: '',
+        tag_snippets: '',
+        type: '',
+        view_through_lookback_window_days: '',
+    },
 }
 
 export default entities

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -224,6 +224,15 @@ const entities: { [key: string]: object } = {
         type: '',
         view_through_lookback_window_days: '',
     },
+    geo_target_constant: {
+        canonical_name: '',
+        country_code: '',
+        id: '',
+        name: '',
+        resource_name: '',
+        status: '',
+        target_type: '',
+    },
 }
 
 export default entities

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const ADWORDS_API_BASE_URL = 'https://googleads.googleapis.com/v0/customers/'
+export const ADWORDS_API_BASE_URL = 'https://googleads.googleapis.com/v0/'
 export const ADWORDS_AUTH_URL = 'https://accounts.google.com/o/oauth2/token'
 
 export enum ENDPOINTS {
@@ -14,6 +14,7 @@ export enum ENDPOINTS {
     shared_sets = 'sharedSets',
     shared_set_criteria = 'sharedCriteria',
     conversion_actions = 'conversionActions',
+    geo_target_constants = 'geoTargetConstants',
 }
 
 export enum RESOURCE_NAMES {
@@ -27,4 +28,5 @@ export enum RESOURCE_NAMES {
     shared_set = 'shared_set',
     shared_set_criterion = 'shared_criterion',
     conversion_action = 'conversion_action',
+    geo_target_constant = 'geo_target_constant',
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ export enum ENDPOINTS {
     adgroup_critera = 'adGroupCriteria',
     shared_sets = 'sharedSets',
     shared_set_criteria = 'sharedCriteria',
+    conversion_actions = 'conversionActions',
 }
 
 export enum RESOURCE_NAMES {
@@ -25,4 +26,5 @@ export enum RESOURCE_NAMES {
     adgroup_critera = 'ad_group_criterion',
     shared_set = 'shared_set',
     shared_set_criterion = 'shared_criterion',
+    conversion_action = 'conversion_action',
 }

--- a/src/entities/ConversionActions.ts
+++ b/src/entities/ConversionActions.ts
@@ -1,0 +1,15 @@
+import Entity from './Entity'
+import { ENDPOINTS, RESOURCE_NAMES } from '../constants'
+
+import { HttpController } from '../types/Http'
+import { NewConversionActionConfig } from './../types/ConversionAction'
+
+export default class ConversionActions extends Entity {
+    constructor(http_controller: HttpController) {
+        super(http_controller, ENDPOINTS.conversion_actions, RESOURCE_NAMES.conversion_action)
+    }
+
+    create(config: NewConversionActionConfig | NewConversionActionConfig[]): Promise<any> {
+        return super.create(config)
+    }
+}

--- a/src/entities/GeoTargetConstants.ts
+++ b/src/entities/GeoTargetConstants.ts
@@ -1,0 +1,34 @@
+import { HttpController } from '../types/Http'
+import { SuggestGeoTargetConstantConfig } from './../types/GeoTargetConstant'
+
+export default class GeoTargetConstants {
+    private http_controller: HttpController
+    private endpoint: string
+
+    /**
+     * GeoTargetConstants
+     * @constructor
+     */
+    constructor(http_controller: HttpController, endpoint: string, resource: string) {
+        this.http_controller = http_controller
+        this.endpoint = endpoint
+    }
+
+    /**
+     * Suggests Geo Target Constants
+     * @param {object} config
+     * @param {integer} config.limit
+     * @param {object} config.constraints
+     */
+    public suggest(config?: SuggestGeoTargetConstantConfig): Promise<any> {
+        return this.http_controller.suggest(config as SuggestGeoTargetConstantConfig, this.endpoint)
+    }
+
+    /**
+     * Retrieves Single Campaign Shared Set
+     * @param {string} geo_target_constant_id
+     */
+    public retrieve(geo_target_constant_id: string | number): Promise<any> {
+        return this.http_controller.retrieve(this.endpoint, geo_target_constant_id)
+    }
+}

--- a/src/entities/GeoTargetConstants.ts
+++ b/src/entities/GeoTargetConstants.ts
@@ -25,7 +25,7 @@ export default class GeoTargetConstants {
     }
 
     /**
-     * Retrieves Single Campaign Shared Set
+     * Retrieves Single Geo Target Constant
      * @param {string} geo_target_constant_id
      */
     public retrieve(geo_target_constant_id: string | number): Promise<any> {

--- a/src/tests/CampaignAdSchedules.test.ts
+++ b/src/tests/CampaignAdSchedules.test.ts
@@ -15,7 +15,7 @@ describe('Campaign Ad Schedules', async () => {
         refresh_token: config.refresh_token,
     })
 
-    const campaign_id = 1485014801
+    const campaign_id = config.testing.campaign_id
     let criterion_id = ''
     let criterion_id_1 = ''
     let criterion_id_2 = ''

--- a/src/tests/adgroupAds.test.ts
+++ b/src/tests/adgroupAds.test.ts
@@ -17,7 +17,7 @@ describe('AdGroup Ads', async () => {
     let ad_id = ''
     let ad_id_1 = ''
     let ad_id_2 = ''
-    const ad_group_id = 56328868446
+    const ad_group_id = config.testing.ad_group_id
 
     it('Lists All AdGroup Ads', async () => {
         expect.assertions(1)

--- a/src/tests/adgroupKeywords.test.ts
+++ b/src/tests/adgroupKeywords.test.ts
@@ -17,7 +17,7 @@ describe('AdGroup Keywords', async () => {
         refresh_token: config.refresh_token,
     })
 
-    const ad_group_id = 60170225920
+    const ad_group_id = config.testing.ad_group_id
     let keyword_id = ''
     let keyword_id_1 = ''
     let keyword_id_2 = ''

--- a/src/tests/adgroups.test.ts
+++ b/src/tests/adgroups.test.ts
@@ -17,7 +17,7 @@ describe('AdGroups', async () => {
         refresh_token: config.refresh_token,
     })
 
-    const campaign_id = 1485014801
+    const campaign_id = config.testing.campaign_id
     let new_adgroup_id = ''
     let new_adgroup_id_1 = ''
     let new_adgroup_id_2 = ''

--- a/src/tests/campaignNegatives.test.ts
+++ b/src/tests/campaignNegatives.test.ts
@@ -20,7 +20,7 @@ describe('Campaign Negatives', async () => {
         refresh_token: config.refresh_token,
     })
 
-    const campaign_id = 1485014801
+    const campaign_id = config.testing.campaign_id
     let criterion_id = ''
 
     it('Lists Campaign Negatives', async () => {

--- a/src/tests/campaignSharedSets.test.ts
+++ b/src/tests/campaignSharedSets.test.ts
@@ -15,8 +15,8 @@ describe('Campaign Shared Sets', async () => {
         refresh_token: config.refresh_token,
     })
 
-    const campaign_id = 1485014801
-    const shared_set_id = 1788591305
+    const campaign_id = config.testing.campaign_id
+    const shared_set_id = config.testing.shared_set_id
     const campaign_shared_set = `${campaign_id}_${shared_set_id}`
 
     it('Creates New Campaign Shared Set', async done => {

--- a/src/tests/conversionActions.test.ts
+++ b/src/tests/conversionActions.test.ts
@@ -3,7 +3,7 @@ import config from '../config'
 jest.setTimeout(30000)
 
 const getRandomConversionActionName = () =>
-    `test-conversion-action-${(Math.random() * 100 + 1).toFixed(0)} (created during library test)`
+    `test-conversion-action-${(Math.random() * 10000000 + 1).toFixed(0)} (created during library test)`
 
 describe('ConversionActions', async () => {
     const lib_instance = new GoogleAdsApi({
@@ -25,7 +25,7 @@ describe('ConversionActions', async () => {
     it('Lists All ConversionActions', async () => {
         expect.assertions(1)
         const conversion_actions = await customer.conversionActions.list({
-            order_by: ['id'],
+            order_by: 'id',
         })
         expect(conversion_actions).toBeInstanceOf(Array)
     })
@@ -34,7 +34,7 @@ describe('ConversionActions', async () => {
         expect.assertions(1)
 
         const new_conversion_action = await customer.conversionActions.create({
-            name: getRandomConversionActionName(),
+            name: getRandomConversionActionName() + '1',
             type: 'AD_CALL',
             category: 'LEAD',
             include_in_conversions_metric: true,
@@ -64,7 +64,7 @@ describe('ConversionActions', async () => {
 
         const new_conversion_actions = await customer.conversionActions.create([
             {
-                name: getRandomConversionActionName(),
+                name: getRandomConversionActionName() + '2',
                 type: 'AD_CALL',
                 category: 'LEAD',
                 include_in_conversions_metric: true,
@@ -80,7 +80,7 @@ describe('ConversionActions', async () => {
                 phone_call_duration_seconds: 45,
             },
             {
-                name: getRandomConversionActionName(),
+                name: getRandomConversionActionName() + '3',
                 type: 'WEBPAGE',
                 category: 'SIGNUP',
                 include_in_conversions_metric: true,
@@ -113,65 +113,77 @@ describe('ConversionActions', async () => {
         done()
     })
 
-    it('Retrieves Single ConversionAction', async () => {
-        expect.assertions(1)
-        const conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
-        expect(new_conversion_action_id).toContain(conversion_action.id)
+    it('Retrieves Single ConversionAction', async done => {
+        setTimeout(async () => {
+            expect.assertions(1)
+            const conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
+            expect(new_conversion_action_id).toContain(conversion_action.id)
+        }, 1000)
+
+        done()
     })
 
-    it('Updates ConversionAction', async () => {
-        expect.assertions(1)
-        const new_conversion_action_name = getRandomConversionActionName()
-        await customer.conversionActions.update({
-            id: new_conversion_action_id,
-            update: {
-                name: new_conversion_action_name,
-            },
-        })
-        const updated_conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
-        expect(updated_conversion_action.name).toEqual(new_conversion_action_name)
+    it('Updates ConversionAction', async done => {
+        setTimeout(async () => {
+            expect.assertions(1)
+            const new_conversion_action_name = getRandomConversionActionName()
+            await customer.conversionActions.update({
+                id: new_conversion_action_id,
+                update: {
+                    name: new_conversion_action_name,
+                },
+            })
+            const updated_conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
+            expect(updated_conversion_action.name).toEqual(new_conversion_action_name)
+        }, 1000)
+        done()
     })
 
-    it('Updates Multiple ConversionActions', async () => {
-        expect.assertions(2)
-        const new_conversion_action_name_1 = getRandomConversionActionName()
-        const new_conversion_action_name_2 = getRandomConversionActionName()
+    it('Updates Multiple ConversionActions', async done => {
+        setTimeout(async () => {
+            expect.assertions(1)
+            const new_conversion_action_name_1 = getRandomConversionActionName()
+            const new_conversion_action_name_2 = getRandomConversionActionName()
 
-        const update_config = [
-            {
-                id: new_conversion_action_id_1,
-                update: {
-                    name: new_conversion_action_name_1,
+            const update_config = [
+                {
+                    id: new_conversion_action_id_1,
+                    update: {
+                        name: new_conversion_action_name_1,
+                    },
                 },
-            },
-            {
-                id: new_conversion_action_id_2,
-                update: {
-                    name: new_conversion_action_name_2,
+                {
+                    id: new_conversion_action_id_2,
+                    update: {
+                        name: new_conversion_action_name_2,
+                    },
                 },
-            },
-        ]
+            ]
 
-        await customer.conversionActions.update(update_config)
+            await customer.conversionActions.update(update_config)
 
-        const updated_conversion_action_1 = await customer.conversionActions.retrieve(new_conversion_action_id_1)
-        expect(updated_conversion_action_1.name).toEqual(new_conversion_action_name_1)
-        const updated_conversion_action_2 = await customer.conversionActions.retrieve(new_conversion_action_id_2)
-        expect(updated_conversion_action_2.name).toEqual(new_conversion_action_name_2)
+            const updated_conversion_action_1 = await customer.conversionActions.retrieve(new_conversion_action_id_1)
+            expect(updated_conversion_action_1.name).toEqual(new_conversion_action_name_1)
+            const updated_conversion_action_2 = await customer.conversionActions.retrieve(new_conversion_action_id_2)
+            expect(updated_conversion_action_2.name).toEqual(new_conversion_action_name_2)
+        }, 1000)
+        done()
     })
 
     it('Deletes ConversionActions', async () => {
-        expect.assertions(3)
-        await customer.conversionActions.delete(new_conversion_action_id)
-        const conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
-        expect(conversion_action.status).toBe('REMOVED')
+        setTimeout(async () => {
+            expect.assertions(3)
+            await customer.conversionActions.delete(new_conversion_action_id)
+            const conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
+            expect(conversion_action.status).toBe('REMOVED')
 
-        await customer.conversionActions.delete(new_conversion_action_id_1)
-        const conversion_action1 = await customer.conversionActions.retrieve(new_conversion_action_id_1)
-        expect(conversion_action1.status).toBe('REMOVED')
+            await customer.conversionActions.delete(new_conversion_action_id_1)
+            const conversion_action1 = await customer.conversionActions.retrieve(new_conversion_action_id_1)
+            expect(conversion_action1.status).toBe('REMOVED')
 
-        await customer.conversionActions.delete(new_conversion_action_id_2)
-        const conversion_action2 = await customer.conversionActions.retrieve(new_conversion_action_id_2)
-        expect(conversion_action2.status).toBe('REMOVED')
+            await customer.conversionActions.delete(new_conversion_action_id_2)
+            const conversion_action2 = await customer.conversionActions.retrieve(new_conversion_action_id_2)
+            expect(conversion_action2.status).toBe('REMOVED')
+        }, 1000)
     })
 })

--- a/src/tests/conversionActions.test.ts
+++ b/src/tests/conversionActions.test.ts
@@ -1,0 +1,177 @@
+import GoogleAdsApi from '..'
+import config from '../config'
+jest.setTimeout(30000)
+
+const getRandomConversionActionName = () =>
+    `test-conversion-action-${(Math.random() * 100 + 1).toFixed(0)} (created during library test)`
+
+describe('ConversionActions', async () => {
+    const lib_instance = new GoogleAdsApi({
+        client_id: config.client_id,
+        client_secret: config.client_secret,
+        developer_token: config.developer_token,
+    })
+
+    const customer = lib_instance.Customer({
+        customer_account_id: config.cid,
+        manager_cid: config.manager_cid,
+        refresh_token: config.refresh_token,
+    })
+
+    let new_conversion_action_id = ''
+    let new_conversion_action_id_1 = ''
+    let new_conversion_action_id_2 = ''
+
+    it('Lists All ConversionActions', async () => {
+        expect.assertions(1)
+        const conversion_actions = await customer.conversionActions.list({
+            order_by: ['id'],
+        })
+        expect(conversion_actions).toBeInstanceOf(Array)
+    })
+
+    it('Creates New ConversionAction', async done => {
+        expect.assertions(1)
+
+        const new_conversion_action = await customer.conversionActions.create({
+            name: getRandomConversionActionName(),
+            type: 'AD_CALL',
+            category: 'LEAD',
+            include_in_conversions_metric: true,
+            click_through_lookback_window_days: 15,
+            value_settings: {
+                default_value: 1,
+                default_currency_code: 'USD',
+            },
+            counting_type: 'ONE_PER_CLICK',
+            attribution_model_settings: {
+                attribution_model: 'GOOGLE_SEARCH_ATTRIBUTION_TIME_DECAY',
+            },
+            phone_call_duration_seconds: 45,
+        })
+
+        expect(new_conversion_action).toEqual({
+            id: expect.any(String),
+            resource_name: expect.any(String),
+        })
+
+        new_conversion_action_id = new_conversion_action.id
+        done()
+    })
+
+    it('Creates 2 New ConversionActions', async done => {
+        expect.assertions(2)
+
+        const new_conversion_actions = await customer.conversionActions.create([
+            {
+                name: getRandomConversionActionName(),
+                type: 'AD_CALL',
+                category: 'LEAD',
+                include_in_conversions_metric: true,
+                click_through_lookback_window_days: 15,
+                value_settings: {
+                    default_value: 1,
+                    default_currency_code: 'USD',
+                },
+                counting_type: 'ONE_PER_CLICK',
+                attribution_model_settings: {
+                    attribution_model: 'GOOGLE_SEARCH_ATTRIBUTION_TIME_DECAY',
+                },
+                phone_call_duration_seconds: 45,
+            },
+            {
+                name: getRandomConversionActionName(),
+                type: 'WEBPAGE',
+                category: 'SIGNUP',
+                include_in_conversions_metric: true,
+                click_through_lookback_window_days: 7,
+                value_settings: {
+                    default_value: 5,
+                    default_currency_code: 'USD',
+                },
+                counting_type: 'MANY_PER_CLICK',
+                attribution_model_settings: {
+                    attribution_model: 'GOOGLE_SEARCH_ATTRIBUTION_POSITION_BASED',
+                },
+            },
+        ])
+
+        expect(new_conversion_actions).toContainEqual(
+            expect.objectContaining({
+                id: expect.any(String),
+                resource_name: expect.any(String),
+            })
+        )
+
+        const conversion_action_ids = new_conversion_actions.map((x: any, i: number) => x.id)
+
+        expect(conversion_action_ids.length).toEqual(2)
+
+        new_conversion_action_id_1 = conversion_action_ids[0]
+        new_conversion_action_id_2 = conversion_action_ids[1]
+
+        done()
+    })
+
+    it('Retrieves Single ConversionAction', async () => {
+        expect.assertions(1)
+        const conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
+        expect(new_conversion_action_id).toContain(conversion_action.id)
+    })
+
+    it('Updates ConversionAction', async () => {
+        expect.assertions(1)
+        const new_conversion_action_name = getRandomConversionActionName()
+        await customer.conversionActions.update({
+            id: new_conversion_action_id,
+            update: {
+                name: new_conversion_action_name,
+            },
+        })
+        const updated_conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
+        expect(updated_conversion_action.name).toEqual(new_conversion_action_name)
+    })
+
+    it('Updates Multiple ConversionActions', async () => {
+        expect.assertions(2)
+        const new_conversion_action_name_1 = getRandomConversionActionName()
+        const new_conversion_action_name_2 = getRandomConversionActionName()
+
+        const update_config = [
+            {
+                id: new_conversion_action_id_1,
+                update: {
+                    name: new_conversion_action_name_1,
+                },
+            },
+            {
+                id: new_conversion_action_id_2,
+                update: {
+                    name: new_conversion_action_name_2,
+                },
+            },
+        ]
+
+        await customer.conversionActions.update(update_config)
+
+        const updated_conversion_action_1 = await customer.conversionActions.retrieve(new_conversion_action_id_1)
+        expect(updated_conversion_action_1.name).toEqual(new_conversion_action_name_1)
+        const updated_conversion_action_2 = await customer.conversionActions.retrieve(new_conversion_action_id_2)
+        expect(updated_conversion_action_2.name).toEqual(new_conversion_action_name_2)
+    })
+
+    it('Deletes ConversionActions', async () => {
+        expect.assertions(3)
+        await customer.conversionActions.delete(new_conversion_action_id)
+        const conversion_action = await customer.conversionActions.retrieve(new_conversion_action_id)
+        expect(conversion_action.status).toBe('REMOVED')
+
+        await customer.conversionActions.delete(new_conversion_action_id_1)
+        const conversion_action1 = await customer.conversionActions.retrieve(new_conversion_action_id_1)
+        expect(conversion_action1.status).toBe('REMOVED')
+
+        await customer.conversionActions.delete(new_conversion_action_id_2)
+        const conversion_action2 = await customer.conversionActions.retrieve(new_conversion_action_id_2)
+        expect(conversion_action2.status).toBe('REMOVED')
+    })
+})

--- a/src/tests/conversionActions.test.ts
+++ b/src/tests/conversionActions.test.ts
@@ -25,7 +25,7 @@ describe('ConversionActions', async () => {
     it('Lists All ConversionActions', async () => {
         expect.assertions(1)
         const conversion_actions = await customer.conversionActions.list({
-            order_by: 'id',
+            order_by: ['id'],
         })
         expect(conversion_actions).toBeInstanceOf(Array)
     })
@@ -34,7 +34,7 @@ describe('ConversionActions', async () => {
         expect.assertions(1)
 
         const new_conversion_action = await customer.conversionActions.create({
-            name: getRandomConversionActionName() + '1',
+            name: getRandomConversionActionName(),
             type: 'AD_CALL',
             category: 'LEAD',
             include_in_conversions_metric: true,
@@ -64,7 +64,7 @@ describe('ConversionActions', async () => {
 
         const new_conversion_actions = await customer.conversionActions.create([
             {
-                name: getRandomConversionActionName() + '2',
+                name: getRandomConversionActionName(),
                 type: 'AD_CALL',
                 category: 'LEAD',
                 include_in_conversions_metric: true,
@@ -80,7 +80,7 @@ describe('ConversionActions', async () => {
                 phone_call_duration_seconds: 45,
             },
             {
-                name: getRandomConversionActionName() + '3',
+                name: getRandomConversionActionName(),
                 type: 'WEBPAGE',
                 category: 'SIGNUP',
                 include_in_conversions_metric: true,

--- a/src/tests/customer.test.ts
+++ b/src/tests/customer.test.ts
@@ -15,9 +15,12 @@ describe('Customer', async () => {
         refresh_token: config.refresh_token,
     })
 
+    let customer_name: string
+
     it('Retrieves Customer Data', async () => {
         expect.assertions(1)
         const customer_data = await customer.retrieve()
+        customer_name = customer_data.descriptive_name
         expect(customer_data).toBeInstanceOf(Object)
     })
 
@@ -33,5 +36,18 @@ describe('Customer', async () => {
         `)
         // console.log(data)
         expect(data).toBeInstanceOf(Array)
+    })
+
+    it('Updates a customer', async () => {
+        expect.assertions(2)
+        const customer_data = await customer.update({
+            update: { descriptive_name: 'Testing' },
+        })
+        expect(customer_data).toBeInstanceOf(Object)
+        const customer_updated_data = await customer.retrieve()
+        expect(customer_updated_data.descriptive_name).toEqual('Testing')
+        await customer.update({
+            update: { descriptive_name: customer_name },
+        })
     })
 })

--- a/src/tests/geoTargetConstants.test.ts
+++ b/src/tests/geoTargetConstants.test.ts
@@ -1,0 +1,39 @@
+import GoogleAdsApi from '..'
+import config from '../config'
+jest.setTimeout(30000)
+
+describe('Geo Target Constants', async () => {
+    const lib_instance = new GoogleAdsApi({
+        client_id: config.client_id,
+        client_secret: config.client_secret,
+        developer_token: config.developer_token,
+    })
+
+    const customer = lib_instance.Customer({
+        customer_account_id: config.cid,
+        manager_cid: config.manager_cid,
+        refresh_token: config.refresh_token,
+    })
+
+    const location_id = '1021278'
+
+    it('Retrieves Single Geo Target Constant', async () => {
+        expect.assertions(1)
+        const geo_target_constant = await customer.geoTargetConstants.retrieve(location_id)
+        expect(geo_target_constant.name).toEqual('Raleigh')
+    })
+
+    it('Suggests Geo Target Constants', async () => {
+        expect.assertions(1)
+
+        const geo_target_constants = await customer.geoTargetConstants.suggest({
+            locale: 'en',
+            country_code: 'US',
+            location_names: {
+                names: ['mountain view'],
+            },
+        })
+
+        expect(geo_target_constants.geoTargetConstantSuggestions).toBeInstanceOf(Array)
+    })
+})

--- a/src/types/ConversionAction.ts
+++ b/src/types/ConversionAction.ts
@@ -1,0 +1,188 @@
+import { Entity, NewEntityConfig } from './Entity'
+
+declare namespace ConversionAction {
+    /**
+     * Main ConversionAction Interface
+     * @interface
+     */
+    export interface ConversionAction extends Entity {
+        // resource_name: string
+        // id: string
+        // name: string
+        status: ConversionActionStatus
+        type: ConversionActionType
+        category: ConversionActionCategory
+        owner_customer: string
+        include_in_conversions_metric: boolean
+        click_through_lookback_window_days: number
+        view_through_lookback_window_days: number
+        value_settings: ValueSettings
+        counting_type: ConversionActionCountingType
+        attribution_model_settings: AttributionModelSettings
+        tag_snippets: TagSnippet[]
+        phone_call_duration_seconds: number
+        app_id: string
+    }
+
+    /**
+     * Enum for ConversionActionStatus
+     * @readonly
+     * @enum {string}
+     */
+    enum ConversionActionStatus {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        ENABLED = 'ENABLED',
+        REMOVED = 'REMOVED',
+        HIDDEN = 'HIDDEN',
+    }
+
+    /**
+     * Enum for ConversionActionType
+     * @readonly
+     * @enum {string}
+     */
+    enum ConversionActionType {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        AD_CALL = 'AD_CALL',
+        CLICK_TO_CALL = 'CLICK_TO_CALL',
+        GOOGLE_PLAY_DOWNLOAD = 'GOOGLE_PLAY_DOWNLOAD',
+        GOOGLE_PLAY_IN_APP_PURCHASE = 'GOOGLE_PLAY_IN_APP_PURCHASE',
+        UPLOAD_CALLS = 'UPLODAD_CALLS',
+        UPLOAD_CLICKS = 'UPLOAD_CLICKS',
+        WEBPAGE = 'WEBPAGE',
+        WESITE_CALL = 'WEBSITE_CALL',
+    }
+
+    /**
+     * Enum for ConversionActionCategory
+     * @readonly
+     * @enum {string}
+     */
+    enum ConversionActionCategory {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        DEFAULT = 'DEFAULT',
+        PAGE_VIEW = 'PAGE_VIEW',
+        PURCHASE = 'PURCHASE',
+        SIGNUP = 'SIGNUP',
+        LEAD = 'LEAD',
+        DOWNLOAD = 'DOWNLOAD',
+    }
+
+    /**
+     * Enum for ConversionActionCountingType
+     * @readonly
+     * @enum {string}
+     */
+    enum ConversionActionCountingType {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        ONE_PER_CLICK = 'ONE_PER_CLICK',
+        MANY_PER_CLICK = 'MANY_PER_CLICK',
+    }
+
+    /**
+     * Enum for AttributionModel
+     * @readonly
+     * @enum {string}
+     */
+    enum AttributionModel {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        GOOGLE_ADS_LAST_CLICK = 'GOOGLE_ADS_LAST_CLICK',
+        GOOGLE_SEARCH_ATTRIBUTION_FIRST_CLICK = 'GOOGLE_SEARCH_ATTRIBUTION_FIRST_CLICK',
+        GOOGLE_SEARCH_ATTRIBUTION_LINEAR = 'GOOGLE_SEARCH_ATTRIBUTION_LINEAR',
+        GOOGLE_SEARCH_ATTRIBUTION_TIME_DECAY = 'GOOGLE_SEARCH_ATTRIBUTION_TIME_DECAY',
+        GOOGLE_SEARCH_ATTRIBUTION_POSITION_BASED = 'GOOGLE_SEARCH_ATTRIBUTION_POSITION_BASED',
+        GOOGLE_SEARCH_ATTRIBUTION_DATA_DRIVEN = 'GOOGLE_SEARCH_ATTRIBUTION_DATA_DRIVEN',
+    }
+
+    /**
+     * Enum for DataDrivenModelStatus
+     * @readonly
+     * @enum {string}
+     */
+    enum DataDrivenModelStatus {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        AVAILABLE = 'AVAILABLE',
+        STALE = 'STALE',
+        EXPIRED = 'EXPIRED',
+        NEVER_GENERATED = 'NEVER_GENERATED',
+    }
+
+    /**
+     * Enum for TrackingCodeType
+     * @readonly
+     * @enum {string}
+     */
+    enum TrackingCodeType {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        WEBPAGE = 'WEBPAGE',
+        WEBPAGE_ONCLICK = 'WEBPAGE_ONCLICK',
+        CLICK_TO_CALL = 'CLICK_TO_CALL',
+    }
+
+    /**
+     * Enum for TrackingCodePageFormat
+     * @readonly
+     * @enum {string}
+     */
+    enum TrackingCodePageFormat {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        HTML = 'HTML',
+        AMP = 'AMP',
+    }
+
+    /**
+     * Interface for ValueSettings
+     * @interface
+     */
+    export interface ValueSettings {
+        default_value?: number
+        default_currency_code?: string
+        always_use_default_value?: boolean
+    }
+
+    /**
+     * Interface for AttributionModelSettings
+     * @interface
+     */
+    export interface AttributionModelSettings {
+        attribution_model?: AttributionModel | string
+        data_driven_model_status?: DataDrivenModelStatus
+    }
+
+    /**
+     * Interface for TagSnippet
+     * @interface
+     */
+    export interface TagSnippet {
+        type: TrackingCodeType
+        page_format: TrackingCodePageFormat
+        global_site_tag: string
+        event_snippet: string
+    }
+
+    /**
+     *  NewConversionActionConfig Interface
+     * @interface
+     */
+    export interface NewConversionActionConfig extends NewEntityConfig {
+        type?: ConversionActionType | string
+        category?: ConversionActionCategory | string
+        include_in_conversions_metric?: boolean
+        click_through_lookback_window_days?: number
+        view_through_lookback_window_days?: number
+        value_settings?: ValueSettings
+        counting_type?: ConversionActionCountingType | string
+        attribution_model_settings?: AttributionModelSettings
+        phone_call_duration_seconds?: number
+        app_id?: string
+    }
+}
+export = ConversionAction

--- a/src/types/Customer.ts
+++ b/src/types/Customer.ts
@@ -11,7 +11,7 @@ import Keywords from '../entities/Keywords'
 import SharedSets from '../entities/SharedSets'
 import SharedSetCriterions from '../entities/SharedSetCriterions'
 
-import { ReportConfig } from './Global'
+import { ReportConfig, UpdateConfig } from './Global'
 
 declare namespace Customer {
     /**
@@ -31,6 +31,7 @@ declare namespace Customer {
         keywords: Keywords
         sharedSets: SharedSets
         sharedSetCriterions: SharedSetCriterions
+        update: (config: UpdateConfig) => Promise<any>
         retrieve: () => Promise<any>
         query: (query: string) => Promise<any>
         report: (config: ReportConfig) => Promise<any>

--- a/src/types/Customer.ts
+++ b/src/types/Customer.ts
@@ -10,6 +10,7 @@ import AdGroupCriterions from '../entities/AdGroupCriterions'
 import Keywords from '../entities/Keywords'
 import SharedSets from '../entities/SharedSets'
 import SharedSetCriterions from '../entities/SharedSetCriterions'
+import ConversionActions from '../entities/ConversionActions'
 
 import { ReportConfig, UpdateConfig } from './Global'
 
@@ -31,6 +32,7 @@ declare namespace Customer {
         keywords: Keywords
         sharedSets: SharedSets
         sharedSetCriterions: SharedSetCriterions
+        conversionActions: ConversionActions
         update: (config: UpdateConfig) => Promise<any>
         retrieve: () => Promise<any>
         query: (query: string) => Promise<any>

--- a/src/types/Customer.ts
+++ b/src/types/Customer.ts
@@ -11,6 +11,7 @@ import Keywords from '../entities/Keywords'
 import SharedSets from '../entities/SharedSets'
 import SharedSetCriterions from '../entities/SharedSetCriterions'
 import ConversionActions from '../entities/ConversionActions'
+import GeoTargetConstants from '../entities/GeoTargetConstants'
 
 import { ReportConfig, UpdateConfig } from './Global'
 
@@ -33,6 +34,7 @@ declare namespace Customer {
         sharedSets: SharedSets
         sharedSetCriterions: SharedSetCriterions
         conversionActions: ConversionActions
+        geoTargetConstants: GeoTargetConstants
         update: (config: UpdateConfig) => Promise<any>
         retrieve: () => Promise<any>
         query: (query: string) => Promise<any>

--- a/src/types/GeoTargetConstant.ts
+++ b/src/types/GeoTargetConstant.ts
@@ -1,0 +1,58 @@
+import { Entity } from './Entity'
+
+declare namespace GeoTargetConstant {
+    /**
+     * Main GeoTargetConstant Interface
+     * @interface
+     */
+    export interface GeoTargetConstant extends Entity {
+        // resource_name: string
+        // id: string
+        // name: string
+        country_code: string
+        target_type: string
+        status: GeoTargetConstantStatus
+        canonical_name: string
+    }
+
+    /**
+     * Enum for GeoTargetConstantStatus
+     * @readonly
+     * @enum {string}
+     */
+    enum GeoTargetConstantStatus {
+        UNSPECIFIED = 'UNSPECIFIED',
+        UNKNOWN = 'UNKNOWN',
+        ENABLED = 'ENABLED',
+        REMOVAL_PLANNED = 'REMOVAL_PLANNED',
+    }
+
+    /**
+     *  Location Names Interface
+     * @interface
+     */
+    export interface LocationNames {
+        names: string[]
+    }
+
+    /**
+     *  Geo Targets Interface
+     * @interface
+     */
+    export interface GeoTargets {
+        geo_target_constants: string[]
+    }
+
+    /**
+     *  Suggest Method Config Interface
+     * @interface
+     */
+    export interface SuggestGeoTargetConstantConfig {
+        locale?: string
+        country_code?: string
+        location_names?: LocationNames
+        geo_targets?: GeoTargets
+    }
+}
+
+export = GeoTargetConstant

--- a/src/types/Http.ts
+++ b/src/types/Http.ts
@@ -1,5 +1,6 @@
 import { NewEntityConfig, ListConfig } from './Entity'
 import { UpdateConfig, ReportConfig } from './Global'
+import { SuggestGeoTargetConstantConfig } from './GeoTargetConstant'
 
 declare namespace Http {
     /**
@@ -14,6 +15,7 @@ declare namespace Http {
         delete(entity: string, entity_id: string | number): Promise<object>
         query(entity: string): Promise<object>
         report(config: ReportConfig): Promise<object>
+        suggest(config: SuggestGeoTargetConstantConfig, entity: string): Promise<any>
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,9 +24,12 @@ export const getUpdateMask = (update_object: any): string => {
     let mask = ''
     for (const key in update_object) {
         if (isObject(update_object[key])) {
-            mask += Object.keys(update_object[key])
-                .map(child_key => `${key}.${child_key}`)
-                .join(',')
+            mask +=
+                Object.keys(update_object).length === 0
+                    ? key
+                    : Object.keys(update_object[key])
+                          .map(child_key => `${key}.${child_key}`)
+                          .join(',')
         } else {
             mask += `${key},`
         }


### PR DESCRIPTION
This just exposes the update method for the Customer object. That way you can change the customer name, enable auto tagging, enable call reporting, etc.

Edit: Actually if you want to hold off on merging this I'd like to add in the [ConversionActionService](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v0.services#google.ads.googleads.v0.services.ConversionActionService) and everything can be done at once. Unless you'd prefer to keep them separate.