### PR TITLE
Allow empty object for Message data types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export const getUpdateMask = (update_object: any): string => {
     for (const key in update_object) {
         if (isObject(update_object[key])) {
             mask +=
-                Object.keys(update_object).length === 0
+                Object.keys(update_object[key]).length === 0
                     ? key
                     : Object.keys(update_object[key])
                           .map(child_key => `${key}.${child_key}`)


### PR DESCRIPTION
When updating some entities, there are Message data types that can be sent using an empty object and a field mask to set them. For instance, on campaigns, setting the bidding strategy to maximize_conversions would look like this:

```javascript
{ update: { maximize_conversions: {} }
```

The API will accept this and change the bidding strategy as long as the field mask is set. This change will just make sure the field mask is set if the update has an empty object in one of the arguments.