### PR TITLE
update(docs): clarifying the README (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,60 +30,59 @@
   </a>
 </p>
 
-## Features
-- Simple and easy to use API
-- Uses [gRPC](https://grpc.io/) and [Protocol Buffers](https://developers.google.com/protocol-buffers/) internally (recommended by Google)
-- Typescript definitions for all [Google Ads API resources, enums and errors](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.resources)
+# Features
 
-## Installation
+-   Simple and easy to use API
+-   Uses [gRPC](https://grpc.io/) and [Protocol Buffers](https://developers.google.com/protocol-buffers/) internally (recommended by Google)
+-   Typescript definitions for all [Google Ads API resources, enums and errors](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.resources)
+
+# Installation
+
 ```bash
 $ yarn add google-ads-api
 ```
 
-## Example
+# Example
+
 ```javascript
-import { GoogleAdsApi, types, enums } from "google-ads-api"
+import { GoogleAdsApi, types, enums } from 'google-ads-api'
 
 // 1. Create a new client with your credentials
 const client = new GoogleAdsApi({
-    client_id: "<CLIENT_ID>",
-    client_secret: "<CLIENT_SECRET>",
-    developer_token: "<DEVELOPER_TOKEN>"
+    client_id: '<CLIENT_ID>',
+    client_secret: '<CLIENT_SECRET>',
+    developer_token: '<DEVELOPER_TOKEN>',
 })
 
-async function main() {
-  // 2. Load a customer with a valid CID & authentication
-  const customer = client.Customer({
-      customer_account_id: "<CUSTOMER_ACCOUNT_ID>",
-      refresh_token: "<REFRESH_TOKEN>"
-  })
-  
-  // 3. Use the report method for querying customer data
-  const response = await customer.report({
-      entity: 'ad_group',
-      attributes: ['ad_group.id', 'ad_group.name', 'ad_group.status'],
-      metrics: ['metrics.clicks'],
-      segments: ['segments.device'],
-      constraints: ['metrics.impressions > 10'],
-      date_constant: 'LAST_30_DAYS',
-      limit: 5,
-  })
-  
-  // 4. Inspect the data and benefit from ts definitions!
-  for(const row of response) {
-    const { ad_group, metrics } = row
-    if(ad_group.status === enums.AdGroupStatus.ENABLED) {
-      console.log(`Ad group "${ad_group.name}" had ${metrics.clicks} clicks.`)
-    }
-  }
-}
+// 2. Load a customer with a valid CID & authentication
+const customer = client.Customer({
+    customer_account_id: '<CUSTOMER_ACCOUNT_ID>',
+    refresh_token: '<REFRESH_TOKEN>',
+})
 
-main()
+// 3. Use the report method for querying customer data
+const response = await customer.report({
+    entity: 'ad_group',
+    attributes: ['ad_group.id', 'ad_group.name', 'ad_group.status'],
+    metrics: ['metrics.clicks'],
+    segments: ['segments.device'],
+    constraints: ['metrics.impressions > 10'],
+    date_constant: 'LAST_30_DAYS',
+    limit: 5,
+})
+
+// 4. Inspect the data and benefit from ts definitions!
+for (const row of response) {
+    const { ad_group, metrics } = row
+    if (ad_group.status === enums.AdGroupStatus.ENABLED) {
+        console.log(`Ad group "${ad_group.name}" had ${metrics.clicks} clicks.`)
+    }
+}
 ```
 
-## Usage
+# Usage
 
-### Authentication
+## Authentication
 
 ```javascript
 import { GoogleAdsApi } from 'google-ads-api'
@@ -101,33 +100,16 @@ const customer = client.Customer({
 })
 ```
 
-### Basic Usage
-Most Google Ads services, accessible via `customer.<serviceName>`, have a `get` and `list` method for retrieving entity data, **not including** metrics and segments. Other supported services also provide a series of mutate operations, namely `create`, `update` and `delete`. Mutate operation examples can be found in the next section.
+## Basic Usage
 
-```javascript
-// Get single campaign with an id or resource name
-const campaign = await customer.campaigns.get(123123123)
-const campaign = await customer.campaigns.get('customers/123/campaigns/123')
+### Reporting & metrics
 
-// List multiple ad groups
-const ad_groups = await customer.adGroups.list({
-    constraints: ["campaign.id = 123"]
-    limit: 15,
-})
-
-// Query using report method
-const campaigns = await customer.report({
-    entity: 'campaign',
-    attributes: ['campaign.id', 'campaign.name'],
-    metrics: ['metrics.cost', 'metrics.clicks'],
-    segments: ['segments.date'],
-    constraints: [{ status: 'ENABLED' }],
-    from_date: '2019-01-01',
-})
-```
+To get reports with metrics, you'll use `customer.search()` or `customer.query()`.
 
 ### Using GAQL (Google Ads Query Language)
-The `customer.search` allows you to query customer data using GAQL ([Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview)) query strings.
+
+The `customer.search()` method allows you to query customer data using GAQL ([Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview)) query strings. This is great for prototyping and getting results out quickly.
+
 ```javascript
 const campaigns = await customer.search(`
     SELECT 
@@ -150,20 +132,104 @@ const campaigns = await customer.search(`
 `)
 ```
 
+### Using `customer.report()`
+
+The `customer.search()` method is a safer and more structured way to use GAQL. It is also more practical to use when your queries need to be built dynamically. If you are using typescript, it will give you handy autocomplete, too!
+
+```javascript
+const response = await customer.report({
+    entity: 'ad_group', // The SELECT clause of your query
+    attributes: ['ad_group.id', 'ad_group.name', 'ad_group.status'], // The attribute fields of your query
+    metrics: ['metrics.clicks'], // The metric fields of your query
+    segments: ['segments.device'], // The segment fields of your query
+    constraints: ['metrics.impressions > 10'], // The WHERE clause of your query
+    date_constant: 'LAST_30_DAYS', // The DURING clause of your query if using a date constant.
+    limit: 5, // The LIMIT clause of your query.
+})
+
+const response = await customer.report({
+    // the contraints array can come in a few different forms:
+
+    // raw strings, which will be concatenated with "AND"
+    constraints: ['campaign.status = "PAUSED"'],
+
+    // objects with a single value, which is short hand for "="
+    constraints: [
+        {
+            'campaign.status': enums.CampaignStatus.PAUSED,
+        },
+    ],
+
+    // objects with an array value, which is short hand for "IN"
+    constraints: [
+        {
+            'campaign.status': [enums.CampaignStatus.PAUSED, enums.CampaignStatus.ENABLED],
+        },
+    ],
+
+    // A full { key, op (operation), val (value)} object, is the most verbose option
+    constraints: [
+        {
+            key: 'campaign.status',
+            op: ' NOT_IN ',
+            val: enums.CampaignStatus.REMOVED,
+        },
+    ],
+})
+```
+
+### Entities
+
+This library is built around `entities` such as `campaigns`, `adGroups` or `sharedSetCriterions`.
+
+You'll find them on the top-level entity, `customer`.
+
+Each `entity` has a few methods. For example, `campaign` has
+
+-   `customer.campaigns.get()` to get a single campaign
+-   `customer.campaigns.list()` to get all campaigns (without metrics or segments)
+-   `customer.campaigns.create()` to create a new campaign
+-   `customer.campaigns.update()` to update campaign fields such as `campaign.name`
+-   `customer.campaigns.delete()` to delete a campaign
+
+Most entities will have these five methods, but they may also have others depending on what is available in the [Google Ads API](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.services).
+
+### Getting and listing
+
+These operations will get you all fields, unsegmented, without metrics.
+- If you're interested in metrics, please use `customer.report()` or `customer.search()`.
+- The `get()` method is rate limited heavily by google. Use it only for debugging.
+- The `list()` method is designed to get you every single field for an entity. Some entities can be quite large, so consider using `customer.report()` or `customer.search()` to get only the fields you actually need for performance reasons.
+
+```javascript
+// Get single campaign with an id or resource name
+const campaign = await customer.campaigns.get(123123123)
+const campaign = await customer.campaigns.get('customers/123/campaigns/123')
+
+// List multiple ad groups
+const ad_groups = await customer.adGroups.list({
+    constraints: ["campaign.id = 123"]
+    limit: 15,
+})
+
+```
+
 ### Mutations
-Roughly half of the services in the Google Ads API can make use of mutate operations, for creating, updating and deleting entities.
+
+Most entities in the Google Ads API can have mutate methods for creating, updating, and deleting.
 
 #### Create
+
 The `create` method can take a single entity or array of entities, of the specified type e.g. Campaign. You can use the Typescript definitions to see at compile time what properties are available when creating new entities. Optionally, you can supply a second argument with the following options: `validate_only` and `partial_failure`. For more details on these, refer to the [Google Ads API documentation](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.services#google.ads.googleads.v1.services.MutateCampaignsRequest).
 
 The `results` property of the response object will contain the newly created entity resource names.
 
-```typescript
-const campaign: types.Campaign = {
+```javascript
+const campaign = {
     name: 'new-campaign',
     campaign_budget: 'customers/123/campaignBudgets/123',
     advertising_channel_type: enums.AdvertisingChannelType.SEARCH,
-    status: enums.CampaignStatus.PAUSED
+    status: enums.CampaignStatus.PAUSED,
 }
 
 const { results } = await customer.campaigns.create(campaign)
@@ -171,12 +237,13 @@ console.log(results) // ['customers/123/campaigns/123']
 ```
 
 #### Update
+
 The `update` method works the same way as `create` and takes a single entity or array of entities to update. All properties passed (that can be updated) will be updated, so if you **don't want to update an attribute, don't include it**. This method also supports the additional `validate_only` and `partial_failure` options.
 
 The `results` property of the response object will contain the newly created entity resource names.
 
-```typescript
-const campaign: types.Campaign = {
+```javascript
+const campaign = {
     resource_name: `customers/123/campaigns/123`,
     name: 'updated-campaign-name',
 }
@@ -184,14 +251,17 @@ const { results } = await gads.campaigns.update(campaign, { validate_only: true 
 ```
 
 #### Delete
+
 The `delete` method should be provided with a valid resource name, being the entity to remove. Note: When deleting an entity in the Google Ads API, it won't be removed, but simply changed to removed.
-```typescript
+
+```javascript
 await gads.campaigns.delete('customers/123/campaigns/123')
 ```
 
-
 ### Error Handling
+
 To handle errors from the Google Ads API, the best approach is to use the provided error enums, available with the `enums` import. A full list of error types can be found in the [Google Ads API references](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.errors).
+
 ```typescript
 import { enums } from 'google-ads-api'
 
@@ -206,7 +276,9 @@ try {
     }
 }
 ```
-As well as the error code, the `message`, `request_id`, `request` object and grpc `failure` object properties are accessible e.g. 
+
+As well as the error code, the `message`, `request_id`, `request` object and grpc `failure` object properties are accessible e.g.
+
 ```javascript
 console.log(err.message) // "Cannot select fields from the following resource.."
 console.log(err.request_id) // "5Tzsyp_M_9F7oHl_EZh8Ow"
@@ -215,13 +287,14 @@ console.log(err.failure) // gRPC GoogleAdsFailure instance
 ```
 
 ## Utilities
+
 In this library, we also provide a set of helper methods that can assist you during development.
 
-| Method 	| Description 	|
-|-----------------	|----------------------------------------------------------------------------	|
-| `fromMicros` 	| Converts micro value to a normal number 	|
-| `toMicros` 	| Converts a normal number to a micro value 	|
-| `getEnumString` 	| Get the value of an enum as a string (instead of the default number value) 	|
+| Method          | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| `fromMicros`    | Converts micro value to a normal number                                    |
+| `toMicros`      | Converts a normal number to a micro value                                  |
+| `getEnumString` | Get the value of an enum as a string (instead of the default number value) |
 
 ```javascript
 import { fromMicros, toMicros, getEnumString } from 'google-ads-api'
@@ -230,11 +303,11 @@ fromMicros(123300000) // 123.3
 toMicros(123.3) // 123300000
 
 // You must pass the enum name and the value
-getEnumString("AdvertisingChannelType", enums.AdvertisingChannelType.DISPLAY) // "DISPLAY"
+getEnumString('AdvertisingChannelType', enums.AdvertisingChannelType.DISPLAY) // "DISPLAY"
 ```
 
-
 ## Type Definitions
+
 All Typescript definition files for Google Ads resources can be found in our companion library, [google-ads-node](https://github.com/opteo/google-ads-node). Specifically, the files [`resources.ts`](https://github.com/Opteo/google-ads-node/blob/master/src/lib/resources.ts) and [`enums.ts`](https://github.com/Opteo/google-ads-node/blob/master/src/lib/enums.ts) will be useful for referencing if you're using this library in a Typescript environment.
 
 ```typescript
@@ -242,13 +315,14 @@ All Typescript definition files for Google Ads resources can be found in our com
 
 /* .google.ads.googleads.v1.common.TextAdInfo */
 export interface TextAdInfo {
-  headline?: string;
-  description_1?: string;
-  description_2?: string;
+    headline?: string
+    description_1?: string
+    description_2?: string
 }
 ```
 
 Both the interfaces and enums can be imported into your project from google-ads-api, as shown below:
+
 ```typescript
 import { types, enums } from "google-ads-api"
 
@@ -260,11 +334,13 @@ if(channel === enums.AdvertisingChannelType.SEARCH) {
 ```
 
 ## Changelog
+
 View the changelog for this library here: https://github.com/Opteo/google-ads-api/blob/master/CHANGELOG.md (only starts from v1.0.1).
 
 Check out the official [Google Ads API release notes](https://developers.google.com/google-ads/api/docs/release-notes) for a detailed changelog.
 
 ## Google Ads Query Language
+
 #### Query Language Grammar
 
 ```


### PR DESCRIPTION
An initial attempt at reorganising the README.

Still todo:
- Add a section about typescript support (since I removed it everywhere else)
- Make examples more consistent