### PR TITLE
Updated and fix Campaign Budget service

### DIFF
--- a/docs/resources/campaign.md
+++ b/docs/resources/campaign.md
@@ -40,7 +40,7 @@ Campaign {
 
 <br/><br/><br/>
 # Create Campaign
-When you create a new campaign, you need to pass an identifier of a shared campaign budget to assign it to the new campaign. If you don't have shared campaign budget, you can create a new campaign budget using [Campaign Budget service](/resources/campaignBudget?id=create-campaign-budget).
+When you create a new campaign, you need to pass an identifier of a shared campaign budget to assign it to the new campaign. If you don't have shared campaign budget, you can create a new campaign budget using [Campaign Budget service](https://github.com/Opteo/google-ads-api/blob/master/docs/resources/campaignBudget.md#create-campaign-budget).
 
 ### Arguments
  Argument       | Type    | Required


### PR DESCRIPTION
The link linking to Campaign Budget Service in Campaign Budget is re-directing to 404 page, fixed it to redirect to proper page