### PR TITLE
Global customer mutate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,14 +274,14 @@ By default, `mutateResources` is atomic and will halt if one operation fails. Th
 await customer.mutateResources(operations, { partial_failure: true })
 ```
 
-As well as creating resources, `mutateResources` also supports updating and deleting multiple resources (which also work with temporary resource ids). Use the `_operation` field in an operation to specify the mode, being either `create`, `update` or `delete`. This field isn't required, and by default is set to `create`. In the example below, the following is done:
+As well as creating resources, `mutateResources` also supports updating and deleting multiple resources (which also works with temporary resource ids). Use the `_operation` field in an operation to specify the mode, being either `create`, `update` or `delete`. This field isn't required, and by default is set to `create`. In the example below, the following is done:
 
 1. A new campaign budget with the temporary resource id `-1` is created.
 2. An existing campaign (id of `456`) is updated to use the new campaign budget (`-1`)
 3. The original campaign budget that was being used by the campaign is deleted
 
 ```javascript
-const response = await customer_no_metrics.mutateResources([
+const response = await customer.mutateResources([
     {
         _resource: 'CampaignBudget',
         _operation: 'create',

--- a/README.md
+++ b/README.md
@@ -237,6 +237,46 @@ const ad_groups = await customer.adGroups.list({
 
 Most entities in the Google Ads API will have mutation methods for creating, updating, and deleting. We also support a top-level customer `mutateResources` method, that allows for performing mutations with different types atomically, as well as supporting the new concept of temporary resource ids.
 
+#### Create
+
+The `create` method can take a single entity or array of entities. Optionally, you can supply a second argument with the following options: `validate_only` and `partial_failure`. For more details on these, refer to the [Google Ads API documentation](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.services#google.ads.googleads.v1.services.MutateCampaignsRequest).
+
+The `results` property of the response object will contain the newly created entity resource names.
+
+```javascript
+const campaign = {
+    name: 'new-campaign',
+    campaign_budget: 'customers/123/campaignBudgets/123',
+    advertising_channel_type: enums.AdvertisingChannelType.SEARCH,
+    status: enums.CampaignStatus.PAUSED,
+}
+
+const { results } = await customer.campaigns.create(campaign)
+console.log(results) // ['customers/123/campaigns/456']
+```
+
+#### Update
+
+The `update` method works the same way as `create` and takes a single entity or array of entities to update. All properties passed (that can be updated) will be updated, so if you **don't want to update an attribute, don't include it**. This method also supports the additional `validate_only` and `partial_failure` options.
+
+The `results` property of the response object will contain the updated entity resource names.
+
+```javascript
+const campaign = {
+    resource_name: `customers/123/campaigns/123`,
+    name: 'updated-campaign-name',
+}
+const { results } = await customer.campaigns.update(campaign, { validate_only: true })
+```
+
+#### Delete
+
+The `delete` method should be provided with the resource name of the entity to remove. Note: When deleting an entity in the Google Ads API, it will continue to exist, but it will be immutable and its status will be changed to `REMOVED`.
+
+```javascript
+await customer.campaigns.delete('customers/123/campaigns/123')
+```
+
 #### Using `customer.mutateResources()`
 
 Sometimes you may want to create multiple resources of different types at once, for example, creating a new campaign and it's required campaign budget. The `customer.mutateResources` method is designed for this use case, and supports temporary resource ids. A basic example of creating a campaign budget and a campaign (which uses this budget) is shown below:
@@ -302,46 +342,6 @@ const response = await customer.mutateResources([
         resource_name: 'customers/123/campaignBudgets/123123',
     },
 ])
-```
-
-#### Create
-
-The `create` method can take a single entity or array of entities. Optionally, you can supply a second argument with the following options: `validate_only` and `partial_failure`. For more details on these, refer to the [Google Ads API documentation](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.services#google.ads.googleads.v1.services.MutateCampaignsRequest).
-
-The `results` property of the response object will contain the newly created entity resource names.
-
-```javascript
-const campaign = {
-    name: 'new-campaign',
-    campaign_budget: 'customers/123/campaignBudgets/123',
-    advertising_channel_type: enums.AdvertisingChannelType.SEARCH,
-    status: enums.CampaignStatus.PAUSED,
-}
-
-const { results } = await customer.campaigns.create(campaign)
-console.log(results) // ['customers/123/campaigns/456']
-```
-
-#### Update
-
-The `update` method works the same way as `create` and takes a single entity or array of entities to update. All properties passed (that can be updated) will be updated, so if you **don't want to update an attribute, don't include it**. This method also supports the additional `validate_only` and `partial_failure` options.
-
-The `results` property of the response object will contain the updated entity resource names.
-
-```javascript
-const campaign = {
-    resource_name: `customers/123/campaigns/123`,
-    name: 'updated-campaign-name',
-}
-const { results } = await customer.campaigns.update(campaign, { validate_only: true })
-```
-
-#### Delete
-
-The `delete` method should be provided with the resource name of the entity to remove. Note: When deleting an entity in the Google Ads API, it will continue to exist, but it will be immutable and its status will be changed to `REMOVED`.
-
-```javascript
-await customer.campaigns.delete('customers/123/campaigns/123')
 ```
 
 ### Enums

--- a/README.md
+++ b/README.md
@@ -277,65 +277,75 @@ The `delete` method should be provided with the resource name of the entity to r
 await customer.campaigns.delete('customers/123/campaigns/123')
 ```
 
-#### Using `customer.mutateResources()`
+#### Atomic mutations using `customer.mutateResources()`
 
-Sometimes you may want to create multiple resources of different types at once, for example, creating a new campaign and it's required campaign budget. The `customer.mutateResources` method is designed for this use case, and supports temporary resource ids. A basic example of creating a campaign budget and a campaign (which uses this budget) is shown below:
+Sometimes you may want to create multiple resources of different types at once, such as creating a new campaign and its required budget. The `customer.mutateResources` method is designed for this use case, and supports:
+
+-   **Atomic Mutations**: If any of the operations fail, all other operations will be rolled back.
+-   **Temporary resource ids**: Define your entity relationships using your own temporary IDs.
+-   **All mutation types**: Create, update, and delete resources.
+
+A basic example of creating a budget and a campaign (which uses this budget) is shown below:
 
 ```javascript
 const { results } = await customer.mutateResources([
     {
-        // For each resource, you must specify it's type with the "_resource" key
+        // For each resource, you must specify its type with the "_resource" key
         _resource: 'CampaignBudget',
-        resource_name: `customers/123/campaignBudgets/-1`,
-        name: 'My new campaign budget',
+        resource_name: `customers/123/campaignBudgets/-1`, // We define the new ID as -1
+        name: 'My new budget',
         amount_micros: 3000000,
         explicitly_shared: true,
     },
     {
         _resource: 'Campaign',
-        // This resource name corresponds to the campaign budget above
-        campaign_budget: `customers/123/campaignBudgets/-1`,
+        campaign_budget: `customers/123/campaignBudgets/-1`, // Reference to the budget above
         name: 'My new campaign',
         advertising_channel_type: enums.AdvertisingChannelType.SEARCH,
         status: enums.CampaignStatus.PAUSED,
         manual_cpc: {
             enhanced_cpc_enabled: true,
         },
+        // We don't need to set a temporary resource name here because
+        // nothing else in this operations array depends on this campaign
     },
 ])
 
-// The resource ids will now be defined after performing the operation
+// The real resource ids will now be defined after performing the operation
 console.log(results) // ['customers/123/campaignBudgets/123123', 'customers/123/campaigns/321321']
 ```
 
-By default, `mutateResources` is atomic and will halt if one operation fails. This means, no new resources will be added to the client account if one operation fails. This mode can be disabled by setting the `partial_failure` option to `true`. The `validate_only` option is also supported in this method. See the [Google Ads API documentation](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.services#google.ads.googleads.v1.services.MutateGoogleAdsRequest) for more details on these settings.
+By default, `mutateResources` is atomic and will rollback if one operation fails -- no new resources will be added to the client account if one operation fails. This mode can be disabled by setting the `partial_failure` option to `true`. The `validate_only` option is also supported in this method. See the [Google Ads API documentation](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v1.services#google.ads.googleads.v1.services.MutateGoogleAdsRequest) for more details on these settings.
 
 ```javascript
 await customer.mutateResources(operations, { partial_failure: true })
 ```
 
-As well as creating resources, `mutateResources` also supports updating and deleting multiple resources (which also works with temporary resource ids). Use the `_operation` field in an operation to specify the mode, being either `create`, `update` or `delete`. This field isn't required, and by default is set to `create`. In the example below, the following is done:
+As well as creating resources, `mutateResources` also supports updating and deleting multiple resources (which also works with temporary resource ids). Use the `_operation` field in an operation to specify the mode, being either `create`, `update` or `delete`. This field isn't required and defaults to `create`. In the example below, these operations are executed:
 
-1. A new campaign budget with the temporary resource id `-1` is created.
-2. An existing campaign (id of `456`) is updated to use the new campaign budget (`-1`)
-3. The original campaign budget that was being used by the campaign is deleted
+1. A new budget with the temporary resource id `-1` is created.
+2. An existing campaign (id of `456`) is updated to use the new budget (`-1`)
+3. The original budget that was being used by the campaign is deleted
 
 ```javascript
 const response = await customer.mutateResources([
+    // Create new budget
     {
         _resource: 'CampaignBudget',
         _operation: 'create',
         resource_name: 'customers/123/campaignBudgets/-1',
-        name: 'My new campaign budget',
+        name: 'My new budget',
         amount_micros: 3000000,
         explicitly_shared: true,
     },
+    // Update campaign to use new budget
     {
         _resource: 'Campaign',
         _operation: 'update',
         resource_name: 'customers/123/campaigns/456',
-        campaign_budget: 'customers/123/campaignBudgets/-1',
+        campaign_budget: 'customers/123/campaignBudgets/-1', // Reference to budget above
     },
+    // Delete old budget
     {
         _resource: 'CampaignBudget',
         _operation: 'delete',
@@ -343,6 +353,8 @@ const response = await customer.mutateResources([
     },
 ])
 ```
+
+_Note_: Using `customer.mutateResources()` with a single operation is equivalent to using any of the standard `customer.someResource.create|update|delete()` methods, but your ts definitions won't be as good.
 
 ### Enums
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "run-s clean build test:unit",
     "test:lint": "prettier --list-different \"src/**/*.{ts,tsx}\"",
     "test:unit": "jest /tests/",
+    "test:watch": "run-s clean build && run-p \"build -- -w\" \"test:unit -- --watch --runInBand\"",
     "prettier:base": "prettier --parser typescript --single-quote",
     "prettier:check": "npm run prettier:base -- --list-different \"src/**/*.{ts,tsx}\"",
     "prettier:write": "npm run prettier:base -- --write \"src/**/*.{ts,tsx}\""

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -100,7 +100,7 @@ import GrpcClient from './grpc'
 /* Utils */
 import Bottleneck from 'bottleneck'
 import { Customer } from 'google-ads-node/build/lib/resources'
-import { ReportOptions, ServiceCreateOptions, PostReportHook, PreReportHook } from './types'
+import { ReportOptions, ServiceCreateOptions, PostReportHook, PreReportHook, MutateResourceOperation } from './types'
 
 export default function Customer(
     cid: string,
@@ -118,8 +118,8 @@ export default function Customer(
         list: () => cusService.list(),
         get: (id: number | string) => cusService.get(id),
         update: (customer: Customer, options?: ServiceCreateOptions) => cusService.update(customer, options),
-        globalCreate: (operations: Array<any>, options?: ServiceCreateOptions) =>
-            cusService.globalCreate(operations, options),
+        mutateResources: (operations: Array<MutateResourceOperation>, options?: ServiceCreateOptions) =>
+            cusService.mutateResources(operations, options),
 
         /* Services */
         campaigns: new CampaignService(cid, client, throttler, 'CampaignService'),

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -118,6 +118,8 @@ export default function Customer(
         list: () => cusService.list(),
         get: (id: number | string) => cusService.get(id),
         update: (customer: Customer, options?: ServiceCreateOptions) => cusService.update(customer, options),
+        globalCreate: (operations: Array<any>, options?: ServiceCreateOptions) =>
+            cusService.globalCreate(operations, options),
 
         /* Services */
         campaigns: new CampaignService(cid, client, throttler, 'CampaignService'),

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,14 +1,14 @@
 import { get } from 'lodash'
-import { SearchGoogleAdsRequest } from 'google-ads-node'
+import { SearchGoogleAdsRequest, MutateGoogleAdsRequest } from 'google-ads-node'
 
-export class SearchGrpcError extends Error {
+export class GrpcError extends Error {
     public readonly code: number
     public readonly request: object
     public readonly request_id: string
     public readonly location: string
     public readonly failure: any
 
-    constructor(err: any, request: SearchGoogleAdsRequest) {
+    constructor(err: any, request: SearchGoogleAdsRequest | MutateGoogleAdsRequest) {
         const { code, details } = err
 
         super(details)

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -6,7 +6,7 @@ import GrpcClient from '../grpc'
 import Bottleneck from 'bottleneck'
 
 import Service, { Mutation } from './service'
-import { ReportOptions, ServiceCreateOptions, PreReportHook, PostReportHook } from '../types'
+import { ReportOptions, ServiceCreateOptions, PreReportHook, PostReportHook, MutateResourceOperation } from '../types'
 
 export default class CustomerService extends Service {
     private post_report_hook: PostReportHook
@@ -79,7 +79,10 @@ export default class CustomerService extends Service {
     // TODO: Add support for this service method
     // public async create(customer: Customer)
 
-    public async globalCreate(operations: Array<any>, options?: ServiceCreateOptions): Promise<Mutation> {
+    public async mutateResources(
+        operations: Array<MutateResourceOperation>,
+        options?: ServiceCreateOptions
+    ): Promise<Mutation> {
         const request = new grpc.MutateGoogleAdsRequest()
 
         request.setCustomerId(this.cid)

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -115,8 +115,8 @@ export default class CustomerService extends Service {
             const resource_operation = new grpc[`${operation_resource_name}Operation`]()
 
             if (operation_mode) {
-                if (operation_mode !== 'create' && operation_mode !== 'update') {
-                    throw new Error(`"_operation" field must be one of "create"|"update`)
+                if (operation_mode !== 'create' && operation_mode !== 'update' && operation_mode !== 'delete') {
+                    throw new Error(`"_operation" field must be one of "create"|"update"|"delete"`)
                 }
                 if (operation_mode === 'create') {
                     resource_operation.setCreate(pb)
@@ -125,6 +125,14 @@ export default class CustomerService extends Service {
                     resource_operation.setUpdate(pb)
                     const update_mask = getFieldMask(operation)
                     resource_operation.setUpdateMask(update_mask)
+                }
+                if (operation_mode === 'delete') {
+                    // @ts-ignore Types are no use here
+                    if (!pb.toObject().hasOwnProperty('resourceName') || !pb.toObject().resourceName) {
+                        throw new Error(`Must specify "resource_name" to remove when using "delete"`)
+                    }
+                    // @ts-ignore Types are no use here
+                    resource_operation.setRemove(pb.toObject().resourceName)
                 }
             } else {
                 resource_operation.setCreate(pb)

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -102,7 +102,7 @@ export default class CustomerService extends Service {
             }
 
             const operation_resource_name = operation._resource
-            const operation_mode = operation._operation
+            let operation_mode = operation._operation
 
             delete operation._resource
             delete operation._operation
@@ -114,28 +114,31 @@ export default class CustomerService extends Service {
             // @ts-ignore Types are no use here
             const resource_operation = new grpc[`${operation_resource_name}Operation`]()
 
-            if (operation_mode) {
-                if (operation_mode !== 'create' && operation_mode !== 'update' && operation_mode !== 'delete') {
-                    throw new Error(`"_operation" field must be one of "create"|"update"|"delete"`)
-                }
-                if (operation_mode === 'create') {
-                    resource_operation.setCreate(pb)
-                }
-                if (operation_mode === 'update') {
-                    resource_operation.setUpdate(pb)
-                    const update_mask = getFieldMask(operation)
-                    resource_operation.setUpdateMask(update_mask)
-                }
-                if (operation_mode === 'delete') {
-                    // @ts-ignore Types are no use here
-                    if (!pb.toObject().hasOwnProperty('resourceName') || !pb.toObject().resourceName) {
-                        throw new Error(`Must specify "resource_name" to remove when using "delete"`)
-                    }
-                    // @ts-ignore Types are no use here
-                    resource_operation.setRemove(pb.toObject().resourceName)
-                }
-            } else {
+            if (!operation_mode) {
+                operation_mode = 'create'
+            }
+
+            if (operation_mode !== 'create' && operation_mode !== 'update' && operation_mode !== 'delete') {
+                throw new Error(`"_operation" field must be one of "create"|"update"|"delete"`)
+            }
+
+            if (operation_mode === 'create') {
                 resource_operation.setCreate(pb)
+            }
+
+            if (operation_mode === 'update') {
+                resource_operation.setUpdate(pb)
+                const update_mask = getFieldMask(operation)
+                resource_operation.setUpdateMask(update_mask)
+            }
+
+            if (operation_mode === 'delete') {
+                // @ts-ignore Types are no use here
+                if (!pb.toObject().hasOwnProperty('resourceName') || !pb.toObject().resourceName) {
+                    throw new Error(`Must specify "resource_name" to remove when using "delete"`)
+                }
+                // @ts-ignore Types are no use here
+                resource_operation.setRemove(pb.toObject().resourceName)
             }
 
             /* Add operation of resource type to global mutate operation e.g. "MutateOperation.setCampaignBudgetOperation" */

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -177,6 +177,25 @@ export default class Service {
         }
     }
 
+    protected async globalMutate(request: grpc.MutateGoogleAdsRequest): Promise<Mutation> {
+        const service = this.client.getService('GoogleAdsService')
+        try {
+            const response = await service.mutate(request)
+            const parsed_results = this.parseServiceResults([response])[0] as any
+            return {
+                request: request.toObject(),
+                partial_failure_error: parsed_results.partial_failure_error,
+                results: parsed_results.mutate_operation_responses.map((r: any) => {
+                    // @ts-ignore Object.values not recognised
+                    const { resource_name } = Object.values(r)[0]
+                    return resource_name
+                }),
+            }
+        } catch (err) {
+            throw new GrpcError(err, request)
+        }
+    }
+
     protected buildResourceName(resource: string): string {
         if (resource.startsWith('customers/')) {
             return resource

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -6,7 +6,7 @@ import { getFieldMask } from 'google-ads-node/build/lib/utils'
 import GrpcClient from '../grpc'
 import { formatQueryResults, buildReportQuery, parseResult } from '../utils'
 import { ServiceListOptions, ServiceCreateOptions } from '../types'
-import { SearchGrpcError } from '../error'
+import { GrpcError } from '../error'
 import { ReportOptions, PreReportHook, PostReportHook } from '../types'
 
 interface GetOptions {
@@ -194,7 +194,7 @@ export default class Service {
             */
             return parsed_results[0]
         } catch (err) {
-            throw new SearchGrpcError(err, request)
+            throw new GrpcError(err, request)
         }
     }
 
@@ -263,7 +263,7 @@ export default class Service {
             const response = await this.client.searchIterator(this.throttler, request, limit)
             return response
         } catch (err) {
-            throw new SearchGrpcError(err, request)
+            throw new GrpcError(err, request)
         }
     }
 

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -91,24 +91,18 @@ export default class Service {
 
         const operations = []
 
-        if (Array.isArray(options.entity[1])) {
-            for (const entity of options.entity[1]) {
-                const operation = new operationType()
+        // If the user passed in only one entity, convert it to an array of length 1
+        if (!Array.isArray(options.entity[1])) {
+            options.entity[1] = [options.entity[1]]
+        }
 
-                const pb = this.buildResource(options.entity[0], entity)
-                operation.setUpdate(pb)
-
-                const mask = getFieldMask(entity)
-                operation.setUpdateMask(mask)
-
-                operations.push(operation)
-            }
-        } else {
+        for (const entity of options.entity[1] as Array<object>) {
             const operation = new operationType()
-            const pb = this.buildResource(...options.entity)
+
+            const pb = this.buildResource(options.entity[0], entity)
             operation.setUpdate(pb)
 
-            const mask = getFieldMask(options.entity[1])
+            const mask = getFieldMask(entity)
             operation.setUpdateMask(mask)
 
             operations.push(operation)
@@ -136,16 +130,14 @@ export default class Service {
 
         const operations = []
 
-        if (Array.isArray(options.entity[1])) {
-            for (const entity of options.entity[1]) {
-                const operation = new operationType()
-                const pb = this.buildResource(options.entity[0], entity)
-                operation.setCreate(pb)
-                operations.push(operation)
-            }
-        } else {
+        // If the user passed in only one entity, convert it to an array of length 1
+        if (!Array.isArray(options.entity[1])) {
+            options.entity[1] = [options.entity[1]]
+        }
+
+        for (const entity of options.entity[1] as Array<object>) {
             const operation = new operationType()
-            const pb = this.buildResource(...options.entity)
+            const pb = this.buildResource(options.entity[0], entity)
             operation.setCreate(pb)
             operations.push(operation)
         }

--- a/src/tests/customer.test.ts
+++ b/src/tests/customer.test.ts
@@ -186,7 +186,7 @@ describe('customer', () => {
 
     describe('mutate', () => {
         it('should be able to perform mutations with temporary resource ids', async () => {
-            const response = await customer.globalCreate(
+            const response = await customer.mutateResources(
                 [
                     {
                         _resource: 'CampaignBudget',
@@ -230,7 +230,7 @@ describe('customer', () => {
 
         it('should be atomic by default', async () => {
             await expect(
-                customer.globalCreate(
+                customer.mutateResources(
                     [
                         {
                             _resource: 'CampaignBudget',
@@ -257,7 +257,7 @@ describe('customer', () => {
         })
 
         it('should support partial failures', async () => {
-            const response = await customer_no_metrics.globalCreate(
+            const response = await customer_no_metrics.mutateResources(
                 [
                     {
                         _resource: 'CampaignBudget',
@@ -294,7 +294,7 @@ describe('customer', () => {
         })
 
         it('should support specifying the _operation type', async () => {
-            const response = await customer_no_metrics.globalCreate(
+            const response = await customer_no_metrics.mutateResources(
                 [
                     {
                         _resource: 'CampaignBudget',
@@ -326,7 +326,8 @@ describe('customer', () => {
 
         it('should throw an error when the _resource key is missing', async () => {
             try {
-                await customer.globalCreate([{ name: 'wasd' }])
+                // @ts-ignore
+                await customer.mutateResources([{ name: 'wasd' }])
             } catch (err) {
                 expect(err.message).toContain('Missing "_resource"')
             }
@@ -334,7 +335,7 @@ describe('customer', () => {
 
         it('should throw an error if the resource type is invalid', async () => {
             try {
-                await customer.globalCreate([
+                await customer.mutateResources([
                     {
                         _resource: 'CampaignFakeResource',
                         resource_name: `customers/${CID_WITH_METRICS}/campaignBudgets/-1`,

--- a/src/tests/customer.test.ts
+++ b/src/tests/customer.test.ts
@@ -3,6 +3,7 @@ import { AdGroupStatus, CampaignStatus } from 'google-ads-node/build/lib/enums'
 import { enums } from '..'
 
 import { newCustomerWithMetrics, newCustomer, CID, CID_WITH_METRICS, getRandomName, CAMPAIGN_ID } from '../test_utils'
+import { MutateResourceOperation } from '../types'
 const customer = newCustomerWithMetrics()
 const customer_no_metrics = newCustomer()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,13 @@ export interface ServiceCreateOptions {
     partial_failure?: boolean
 }
 
+export interface MutateResourceOperation {
+    _resource: string
+    _operation?: 'create' | 'update' | 'delete'
+    // Allow any resource field
+    [key: string]: any
+}
+
 interface PreQueryHookArgs {
     query: string
     cid: string


### PR DESCRIPTION
This PR adds support for a new global customer mutate method, that supports creating/updating/deleting multiple resources, of different types, in the same query (as well as using temporary resource ids, as per https://github.com/Opteo/google-ads-api/issues/15).

It is atomic by default, and can be changed to continue on failures using the `partial_failure` option. It also supports the already used `validate_only` option. 

~For now, we just support create operations. At some point, we can make it support updates (either here or a new global mutate method). Support for updates has been added, all it requires is using the `_operation` field. By default `_operation` is `"create"`. In the example below, we create a new campaign budget and update an existing campaign to use it:~ **All operations are now supported! Creating, updating and deleting** 🎉 

For some usage examples, check out [the new tests](https://github.com/Opteo/google-ads-api/blob/ccb8e6944dd9ec6b2c4c44805d754e70b46c379a/src/tests/customer.test.ts#L187).