### PR TITLE
Customer interface type

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,7 @@ import Bottleneck from 'bottleneck'
 import crypto from 'crypto'
 import { noop } from 'lodash'
 
-import CustomerInstance from './customer'
+import Customer, { CustomerInstance } from './customer'
 import GrpcClient from './grpc'
 import { normaliseCustomerId } from './utils'
 import { PreReportHook, PostReportHook } from './types'
@@ -61,7 +61,7 @@ export default class GoogleAdsApi {
         login_customer_id,
         pre_report_hook,
         post_report_hook,
-    }: CustomerOptions) {
+    }: CustomerOptions): CustomerInstance {
         if (!customer_account_id || !refresh_token) {
             throw new Error('Must specify {customer_account_id, refresh_token}')
         }
@@ -80,6 +80,6 @@ export default class GoogleAdsApi {
             login_customer_id
         )
 
-        return CustomerInstance(customer_account_id, client, this.throttler, pre_report_hook, post_report_hook)
+        return Customer(customer_account_id, client, this.throttler, pre_report_hook, post_report_hook)
     }
 }

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -92,7 +92,14 @@ import UserListService from './services/user_list'
 import VideoService from './services/video'
 
 /* Customer */
-import CustomerService from './services/customer'
+import CustomerService, {
+    ReportResponse,
+    QueryResponse,
+    ListResponse,
+    GetResponse,
+    UpdateResponse,
+    MutateResourcesResponse,
+} from './services/customer'
 
 /* gRPC Client */
 import GrpcClient from './grpc'
@@ -102,24 +109,121 @@ import Bottleneck from 'bottleneck'
 import { Customer } from 'google-ads-node/build/lib/resources'
 import { ReportOptions, ServiceCreateOptions, PostReportHook, PreReportHook, MutateResourceOperation } from './types'
 
+export interface CustomerInstance {
+    /* Global customer methods */
+    report: (options: ReportOptions) => ReportResponse
+    query: (qry: string) => QueryResponse
+    list: () => ListResponse
+    get: (id: number | string) => GetResponse
+    update: (customer: Customer, options?: ServiceCreateOptions) => UpdateResponse
+    mutateResources: (
+        operations: Array<MutateResourceOperation>,
+        options?: ServiceCreateOptions
+    ) => MutateResourcesResponse
+
+    /* Services */
+    campaigns: CampaignService
+    campaignBudgets: CampaignBudgetService
+    adGroups: AdGroupService
+    accountBudgetProposals: AccountBudgetProposalService
+    accountBudgets: AccountBudgetService
+    adGroupAdLabels: AdGroupAdLabelService
+    adGroupAds: AdGroupAdService
+    adGroupAudienceViews: AdGroupAudienceViewService
+    adGroupBidModifiers: AdGroupBidModifierService
+    adGroupCriterionLabels: AdGroupCriterionLabelService
+    adGroupCriterion: AdGroupCriterionService
+    adGroupExtensionSettings: AdGroupExtensionSettingService
+    adGroupFeeds: AdGroupFeedService
+    adGroupLabels: AdGroupLabelService
+    adScheduleViews: AdScheduleViewService
+    ageRangeViews: AgeRangeViewService
+    assets: AssetService
+    biddingStrategys: BiddingStrategyService
+    billingSetups: BillingSetupService
+    campaignAudienceViews: CampaignAudienceViewService
+    campaignBidModifiers: CampaignBidModifierService
+    campaignCriterion: CampaignCriterionService
+    campaignExtensionSettings: CampaignExtensionSettingService
+    campaignFeeds: CampaignFeedService
+    campaignLabels: CampaignLabelService
+    campaignSharedSets: CampaignSharedSetService
+    carrierConstants: CarrierConstantService
+    changeStatus: ChangeStatusService
+    clickViews: ClickViewService
+    conversionActions: ConversionActionService
+    conversionUploads: ConversionUploadService
+    conversionAdjustmentUploads: ConversionAdjustmentUploadService
+    customInterests: CustomInterestService
+    customerClientLinks: CustomerClientLinkService
+    customerClients: CustomerClientService
+    customerExtensionSettings: CustomerExtensionSettingService
+    customerFeeds: CustomerFeedService
+    customerLabels: CustomerLabelService
+    customerManagerLinks: CustomerManagerLinkService
+    customerNegativeCriterions: CustomerNegativeCriterionService
+    displayKeywordViews: DisplayKeywordViewService
+    domainCategories: DomainCategoryService
+    dynamicSearchAdsSearchTermViews: DynamicSearchAdsSearchTermViewService
+    extensionFeedItems: ExtensionFeedItemService
+    feedItems: FeedItemService
+    feedItemTargets: FeedItemTargetService
+    feedMappings: FeedMappingService
+    feedPlaceholderViews: FeedPlaceholderViewService
+    feeds: FeedService
+    genderViews: GenderViewService
+    geoTargetConstants: GeoTargetConstantService
+    geographicViews: GeographicViewService
+    groupPlacementViews: GroupPlacementViewService
+    hotelGroupViews: HotelGroupViewService
+    hotelPerformanceViews: HotelPerformanceViewService
+    keywordPlanAdGroups: KeywordPlanAdGroupService
+    keywordPlanCampaigns: KeywordPlanCampaignService
+    keywordPlanKeywords: KeywordPlanKeywordService
+    keywordPlanNegativeKeywords: KeywordPlanNegativeKeywordService
+    keywordPlans: KeywordPlanService
+    keywordViews: KeywordViewService
+    labels: LabelService
+    languageConstants: LanguageConstantService
+    locationViews: LocationViewService
+    managedPlacementViews: ManagedPlacementViewService
+    mediaFiles: MediaFileService
+    mobileAppCategoryConstants: MobileAppCategoryConstantService
+    mobileDeviceConstants: MobileDeviceConstantService
+    operatingSystemVersionConstants: OperatingSystemVersionConstantService
+    parentalStatusViews: ParentalStatusViewService
+    productBiddingCategoryConstants: ProductBiddingCategoryConstantService
+    productGroupViews: ProductGroupViewService
+    recommendations: RecommendationService
+    remarketingActions: RemarketingActionService
+    searchTermViews: SearchTermViewService
+    sharedCriterion: SharedCriterionService
+    shoppingPerformanceViews: ShoppingPerformanceViewService
+    sharedSets: SharedSetService
+    topicConstants: TopicConstantService
+    topicViews: TopicViewService
+    userInterests: UserInterestService
+    userLists: UserListService
+    videos: VideoService
+}
+
 export default function Customer(
     cid: string,
     client: GrpcClient,
     throttler: Bottleneck,
     pre_report_hook: PreReportHook,
     post_report_hook: PostReportHook
-) {
+): CustomerInstance {
     const cusService = new CustomerService(cid, client, throttler, 'CustomerService', pre_report_hook, post_report_hook)
 
     return {
         /* Top level customer methods */
-        report: (options: ReportOptions) => cusService.report(options),
-        query: (qry: string) => cusService.query(qry),
+        report: options => cusService.report(options),
+        query: qry => cusService.query(qry),
         list: () => cusService.list(),
-        get: (id: number | string) => cusService.get(id),
-        update: (customer: Customer, options?: ServiceCreateOptions) => cusService.update(customer, options),
-        mutateResources: (operations: Array<MutateResourceOperation>, options?: ServiceCreateOptions) =>
-            cusService.mutateResources(operations, options),
+        get: id => cusService.get(id),
+        update: (customer, options) => cusService.update(customer, options),
+        mutateResources: (operations, options) => cusService.mutateResources(operations, options),
 
         /* Services */
         campaigns: new CampaignService(cid, client, throttler, 'CampaignService'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ import * as types from 'google-ads-node/build/lib/resources'
 
 /* Helpers */
 import { fromMicros, toMicros, getEnumString } from './utils'
+import { CustomerInstance } from './customer'
 
-export { GoogleAdsApi, enums, types, fromMicros, toMicros, getEnumString }
+export { GoogleAdsApi, enums, types, fromMicros, toMicros, getEnumString, CustomerInstance }

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -8,6 +8,13 @@ import Bottleneck from 'bottleneck'
 import Service, { Mutation } from './service'
 import { ReportOptions, ServiceCreateOptions, PreReportHook, PostReportHook, MutateResourceOperation } from '../types'
 
+export type ReportResponse = Promise<Array<any>>
+export type QueryResponse = Promise<Array<any>>
+export type ListResponse = Promise<Array<{ customer: Customer }>>
+export type GetResponse = Promise<Customer>
+export type UpdateResponse = Promise<void>
+export type MutateResourcesResponse = Promise<Mutation>
+
 export default class CustomerService extends Service {
     private post_report_hook: PostReportHook
     private pre_report_hook: PreReportHook
@@ -26,12 +33,12 @@ export default class CustomerService extends Service {
         this.post_report_hook = post_report_hook
     }
 
-    public async report(options: ReportOptions): Promise<Array<any>> {
+    public async report(options: ReportOptions): ReportResponse {
         const results = await this.serviceReport(options, this.pre_report_hook, this.post_report_hook)
         return results
     }
 
-    public async query(qry: string): Promise<Array<any>> {
+    public async query(qry: string): QueryResponse {
         const results = await this.serviceQuery(qry)
         return results
     }
@@ -43,11 +50,11 @@ export default class CustomerService extends Service {
     //     console.log(response)
     // }
 
-    public async list(): Promise<Array<{ customer: Customer }>> {
+    public async list(): ListResponse {
         return this.getListResults('customer')
     }
 
-    public async get(id: number | string): Promise<Customer> {
+    public async get(id: number | string): GetResponse {
         return this.serviceGet({
             request: 'GetCustomerRequest',
             resource: `customers/${id}`,
@@ -56,7 +63,7 @@ export default class CustomerService extends Service {
         }) as Customer
     }
 
-    public async update(customer: Customer, options?: ServiceCreateOptions): Promise<void> {
+    public async update(customer: Customer, options?: ServiceCreateOptions): UpdateResponse {
         const request = new grpc.MutateCustomerRequest()
         const operation = new grpc.CustomerOperation()
 
@@ -82,7 +89,7 @@ export default class CustomerService extends Service {
     public async mutateResources(
         operations: Array<MutateResourceOperation>,
         options?: ServiceCreateOptions
-    ): Promise<Mutation> {
+    ): MutateResourcesResponse {
         const request = new grpc.MutateGoogleAdsRequest()
 
         request.setCustomerId(this.cid)


### PR DESCRIPTION
This PR adds a `Customer` interface type, which can be accessed via the `google-ads-api` import. 

Before, this type was inferred, and didn't work correctly in some TypeScript use-cases. This is purely for TS and doesn't introduce any breaking changes for normal users.

```typescript
import { CustomerInstance } from "google-ads-api"

const customer: CustomerInstance = new client.Customer(...)
```