### PR TITLE
Fix for issue #48

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -84,7 +84,8 @@ export default class GrpcClient {
             response = await this.searchWithRetry(throttler, next_page_request)
             results = results.concat(response.resultsList)
 
-            if (results.length >= limit) {
+            // If there is no limit, `limit` will be set to 0.
+            if (limit && results.length >= limit) {
                 results = results.slice(0, limit)
                 break
             }
@@ -111,7 +112,7 @@ export default class GrpcClient {
         }
 
         const has_limit = query.toLowerCase().includes(' limit ')
-        let limit = 0
+        let limit = 0 // The default limit is 0, which means no limit.
         if (has_limit) {
             limit = +query
                 .toLowerCase()

--- a/src/tests/query_limits.test.ts
+++ b/src/tests/query_limits.test.ts
@@ -85,4 +85,17 @@ describe('Query Limits', async () => {
 
         expect(data).toHaveLength(10)
     })
+
+    it('iterates correctly when no limit is set', async () => {
+        const data = await customer.report({
+            entity: 'customer',
+            attributes: ['customer.id'],
+            segments: ['segments.date'],
+            metrics: ['metrics.impressions'],
+            date_constant: 'LAST_30_DAYS',
+            page_size: 13,
+        })
+
+        expect(data).toHaveLength(30)
+    })
 })


### PR DESCRIPTION
fix(report): Fixed issue with pagination cutting off results when no `limit` is set.