### PR TITLE
feat(report): automatically add quotes around constraint values

### DIFF
--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { getEnumString, enums } from '../index'
-import { translateEnumValue, buildReportQuery } from '../utils'
+import { translateEnumValue, buildReportQuery, verifyConstraintType, addQuotesIfMissing } from '../utils'
 import { ReportOptions } from '../types'
 
 test('getEnumString', () => {
@@ -36,6 +36,34 @@ describe('translateEnumValue', () => {
     })
 })
 
+describe('addQuotesIfMissing', () => {
+    it('should add quotes only when quotes are missing', () => {
+        expect(addQuotesIfMissing(true)).toEqual(`"true"`)
+        expect(addQuotesIfMissing('true')).toEqual(`"true"`)
+        expect(addQuotesIfMissing(`"true"`)).toEqual(`"true"`)
+        expect(addQuotesIfMissing('customer/133/campaign/456')).toEqual(`"customer/133/campaign/456"`)
+        expect(addQuotesIfMissing(`'customer/133/campaign/456'`)).toEqual(`'customer/133/campaign/456'`)
+        expect(addQuotesIfMissing(123)).toEqual(`"123"`)
+        expect(addQuotesIfMissing(`123`)).toEqual(`"123"`)
+        expect(addQuotesIfMissing(`"123"`)).toEqual(`"123"`)
+    })
+})
+
+describe('verifyConstraintType', () => {
+    it('should throw if a constraint value is not of a supported type', () => {
+        expect(() => verifyConstraintType('key', undefined)).toThrow()
+        expect(() => verifyConstraintType('key', null)).toThrow()
+        expect(() => verifyConstraintType('key', { hello: 'yes' })).toThrow()
+        expect(() => verifyConstraintType('key', [1, 'yes'])).toThrow()
+    })
+
+    it('should not throw if a constraint value is of a supported type', () => {
+        expect(() => verifyConstraintType('key', true)).not.toThrow()
+        expect(() => verifyConstraintType('key', 'hello')).not.toThrow()
+        expect(() => verifyConstraintType('key', 123.66)).not.toThrow()
+    })
+})
+
 describe('buildReportQuery', () => {
     it('should translate enums in constraints to their key (string) value', () => {
         const options: ReportOptions = {
@@ -60,7 +88,7 @@ describe('buildReportQuery', () => {
         const query = buildReportQuery(options)
 
         expect(query).toEqual(
-            `SELECT ad_group.name, campaign.name FROM ad_group WHERE ad_group.status = PAUSED AND campaign.advertising_channel_type = SEARCH AND campaign_budget.status = ENABLED AND metrics.clicks > 10`
+            `SELECT ad_group.name, campaign.name FROM ad_group WHERE ad_group.status = "PAUSED" AND campaign.advertising_channel_type = "SEARCH" AND campaign_budget.status = "ENABLED" AND metrics.clicks > "10"`
         )
     })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,12 @@ type DateConstant =
     | 'TODAY'
 
 /**
+ *  Constraint value
+ * @interface
+ */
+export type ConstraintValue = string | number | boolean | Array<string | number | boolean>
+
+/**
  *  Constraint object with full parameters
  * @interface
  */
@@ -206,7 +212,7 @@ export interface Constraint {
         | 'IS NOT NULL'
         | 'DURING'
         | 'BETWEEN'
-    val: string | number | Array<string>
+    val: ConstraintValue
 }
 
 /**


### PR DESCRIPTION
This PR allows more natural constraints:

```javascript
// before
constraints: {
    'campaign.resource_name': `"${rn}"`
}
// after
constraints: {
    'campaign.resource_name': rn
}

```