### PR TITLE
fix(report): allow `IN` clause when using object-style constraints

### DIFF
--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -99,6 +99,25 @@ describe('buildReportQuery', () => {
         )
     })
 
+    it('should support constraints as objects', () => {
+        const options: ReportOptions = {
+            entity: 'ad_group',
+            attributes: ['ad_group.name'],
+            constraints: {
+                'ad_group.name': 'My AdGroup',
+                'ad_group.status': enums.AdGroupStatus.PAUSED,
+                'metrics.clicks': 0,
+                'campaign.id': [123, 456],
+            },
+        }
+
+        const query = buildReportQuery(options)
+
+        expect(query).toEqual(
+            `SELECT ad_group.name FROM ad_group WHERE ad_group.name = "My AdGroup" AND ad_group.status = "PAUSED" AND campaign.id IN ("123","456") AND metrics.clicks = "0"`
+        )
+    })
+
     it(`should throw an error if "val" is undefined`, () => {
         const id = undefined
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,11 +35,8 @@ export function buildReportQuery(config: ReportOptions) {
               }
           )
         : Object.keys(constraints).map(key => {
-              return {
-                  key,
-                  op: '=',
-                  val: (constraints as any)[key],
-              }
+              const val = (constraints as any)[key]
+              return unrollConstraintShorthand({ [key]: val })
           })
 
     /* ATTRIBUTES */


### PR DESCRIPTION
At the moment, this constraint doesn't work:

```javascript
customer.report({
    entity: 'ad_group',
    attributes: ['ad_group.name'],
    constraints: {
        'campaign.id': [123, 456],
    },
})
```

The code always assumes that we want "=", whereas here want "IN" for the operator. This PR corrects this behaviour.