### PR TITLE
Fix case error in mutateBiddingStrategies constant that causes error

### DIFF
--- a/src/services/bidding_strategy.ts
+++ b/src/services/bidding_strategy.ts
@@ -8,7 +8,7 @@ import { ServiceListOptions, ServiceCreateOptions } from '../types'
  * @constants
  */
 const RESOURCE_URL_NAME = 'biddingStrategies'
-const MUTATE_METHOD = 'mutatebiddingStrategies'
+const MUTATE_METHOD = 'mutateBiddingStrategies'
 const MUTATE_REQUEST = 'MutateBiddingStrategiesRequest'
 const OPERATION_REQUEST = 'BiddingStrategyOperation'
 const GET_METHOD = 'getBiddingStrategy'


### PR DESCRIPTION
This fixes an error in creating bidding strategies whereby the function to create was not being found (bidding strategies were unable to be created) due to a discrepancy in the case of the `MUTATE_METHOD` name (`mutatebiddingStrategies` vs. `mutateBiddingStrategies`) in bidding_strategy.js.