### PR TITLE
Add applyRecommendation & dismissRecommendation to Recommendation Service

### DIFF
--- a/src/services/recommendation.ts
+++ b/src/services/recommendation.ts
@@ -32,12 +32,25 @@ export default class RecommendationService extends Service {
         return this.getListResults('recommendation', options)
     }
 
-    public async applyRecommendation(resourceName: string, options?: ServiceCreateOptions): Promise<Mutation> {
+    public async applyRecommendation(
+        resourceName: string | string[],
+        options?: ServiceCreateOptions
+    ): Promise<Mutation> {
         const request = new ApplyRecommendationRequest()
-        const operation = new ApplyRecommendationOperation()
-        operation.setResourceName(resourceName)
         request.setCustomerId(this.cid)
-        request.setOperationsList([operation])
+
+        if (resourceName instanceof Array) {
+            const operations = resourceName.map(name => {
+                const operation = new ApplyRecommendationOperation()
+                operation.setResourceName(name)
+                return operation
+            })
+            request.setOperationsList(operations)
+        } else {
+            const operation = new ApplyRecommendationOperation()
+            operation.setResourceName(resourceName)
+            request.setOperationsList([operation])
+        }
 
         if (options && options.hasOwnProperty('partial_failure')) {
             if (!request.setPartialFailure) {
@@ -54,13 +67,25 @@ export default class RecommendationService extends Service {
         }
     }
 
-    public async dismissRecommendation(resourceName: string, options?: ServiceCreateOptions): Promise<Mutation> {
+    public async dismissRecommendation(
+        resourceName: string | string[],
+        options?: ServiceCreateOptions
+    ): Promise<Mutation> {
         const request = new DismissRecommendationRequest()
-        const operation = new DismissRecommendationRequest.DismissRecommendationOperation()
-        operation.setResourceName(resourceName)
-
         request.setCustomerId(this.cid)
-        request.setOperationsList([operation])
+
+        if (resourceName instanceof Array) {
+            const operations = resourceName.map(name => {
+                const operation = new DismissRecommendationRequest.DismissRecommendationOperation()
+                operation.setResourceName(name)
+                return operation
+            })
+            request.setOperationsList(operations)
+        } else {
+            const operation = new DismissRecommendationRequest.DismissRecommendationOperation()
+            operation.setResourceName(resourceName)
+            request.setOperationsList([operation])
+        }
 
         if (options && options.hasOwnProperty('partial_failure')) {
             if (!request.setPartialFailure) {

--- a/src/services/recommendation.ts
+++ b/src/services/recommendation.ts
@@ -1,6 +1,12 @@
 // @ts-ignore
 import { Recommendation } from 'google-ads-node/build/lib/resources'
-import { ApplyRecommendationRequest, ApplyRecommendationOperation, ApplyRecommendationResponse } from 'google-ads-node'
+import {
+    ApplyRecommendationRequest,
+    ApplyRecommendationOperation,
+    ApplyRecommendationResponse,
+    DismissRecommendationRequest,
+    DismissRecommendationResponse,
+} from 'google-ads-node'
 
 import Service, { Mutation } from './service'
 import { ServiceListOptions, ServiceCreateOptions } from '../types'
@@ -41,6 +47,29 @@ export default class RecommendationService extends Service {
         }
 
         const response: ApplyRecommendationResponse.AsObject = await this.service.applyRecommendation(request)
+        return {
+            request: request.toObject(),
+            partial_failure_error: response.partialFailureError,
+            results: response.resultsList.map(r => r.resourceName),
+        }
+    }
+
+    public async dismissRecommendation(resourceName: string, options?: ServiceCreateOptions): Promise<Mutation> {
+        const request = new DismissRecommendationRequest()
+        const operation = new DismissRecommendationRequest.DismissRecommendationOperation()
+        operation.setResourceName(resourceName)
+
+        request.setCustomerId(this.cid)
+        request.setOperationsList([operation])
+
+        if (options && options.hasOwnProperty('partial_failure')) {
+            if (!request.setPartialFailure) {
+                throw new Error(`This method does not support the partial_failure option.`)
+            }
+            request.setPartialFailure(options.partial_failure as boolean)
+        }
+
+        const response: DismissRecommendationResponse.AsObject = await this.service.dismissRecommendation(request)
         return {
             request: request.toObject(),
             partial_failure_error: response.partialFailureError,

--- a/src/services/recommendation.ts
+++ b/src/services/recommendation.ts
@@ -3,7 +3,7 @@ import { Recommendation } from 'google-ads-node/build/lib/resources'
 import { ApplyRecommendationRequest, ApplyRecommendationOperation, ApplyRecommendationResponse } from 'google-ads-node'
 
 import Service from './service'
-import { ServiceListOptions } from '../types'
+import { ServiceListOptions, ServiceCreateOptions } from '../types'
 
 /**
  * @constants
@@ -25,13 +25,16 @@ export default class RecommendationService extends Service {
     public async list(options?: ServiceListOptions): Promise<Array<{ recommendation: Recommendation }>> {
         return this.getListResults('recommendation', options)
     }
-    
-    public async applyRecommendation(resourceName: string): Promise<ApplyRecommendationResponse.AsObject> {
+
+    public async applyRecommendation(
+        resourceName: string,
+        options?: ServiceCreateOptions
+    ): Promise<ApplyRecommendationResponse.AsObject> {
         const request = new ApplyRecommendationRequest()
         const operation = new ApplyRecommendationOperation()
         operation.setResourceName(resourceName)
         request.setCustomerId(this.cid)
         request.setOperationsList([operation])
-        return this.service.applyRecommendation(request)
+        return this.service.applyRecommendation(request, options)
     }
 }

--- a/src/services/recommendation.ts
+++ b/src/services/recommendation.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { Recommendation } from 'google-ads-node/build/lib/resources'
+import { ApplyRecommendationRequest, ApplyRecommendationOperation, ApplyRecommendationResponse } from 'google-ads-node'
 
 import Service from './service'
 import { ServiceListOptions } from '../types'
@@ -23,5 +24,14 @@ export default class RecommendationService extends Service {
 
     public async list(options?: ServiceListOptions): Promise<Array<{ recommendation: Recommendation }>> {
         return this.getListResults('recommendation', options)
+    }
+    
+    public async applyRecommendation(resourceName: string): Promise<ApplyRecommendationResponse.AsObject> {
+        const request = new ApplyRecommendationRequest()
+        const operation = new ApplyRecommendationOperation()
+        operation.setResourceName(resourceName)
+        request.setCustomerId(this.cid)
+        request.setOperationsList([operation])
+        return this.service.applyRecommendation(request)
     }
 }

--- a/src/tests/recommendation.test.ts
+++ b/src/tests/recommendation.test.ts
@@ -23,7 +23,9 @@ describe('Recommendations', () => {
 
     it('Applies a recommendation', async () => {
         expect.assertions(2)
-        const { resultsList } = await customer.recommendations.applyRecommendation(recommendationResourceName)
+        const { resultsList } = await customer.recommendations.applyRecommendation(recommendationResourceName, {
+            validate_only: true,
+        })
         expect(resultsList instanceof Array).toEqual(true)
         expect(resultsList[0]).toHaveProperty('resourceName')
     })

--- a/src/tests/recommendation.test.ts
+++ b/src/tests/recommendation.test.ts
@@ -1,0 +1,30 @@
+// @ts-ignore
+import { newCustomerWithMetrics } from '../test_utils'
+const customer = newCustomerWithMetrics()
+
+describe('Recommendations', () => {
+    let recommendationResourceName = ''
+
+    // Even though this is in an auto-gen test, we need to get a recommendation to test applying it
+    it('Lists recommendations', async () => {
+        expect.assertions(2)
+        const recommendations = await customer.recommendations.list()
+        expect(recommendations).toBeInstanceOf(Array)
+        expect(typeof recommendations[0].recommendation.resource_name).toEqual('string')
+        recommendationResourceName = recommendations[0].recommendation.resource_name as string
+    })
+
+    it('Gets a recommendation', async () => {
+        expect.assertions(2)
+        const recommendation = await customer.recommendations.get(recommendationResourceName.split('/')[3])
+        expect(recommendation).toBeInstanceOf(Object)
+        expect(typeof recommendation.resource_name).toEqual('string')
+    })
+
+    it('Applies a recommendation', async () => {
+        expect.assertions(2)
+        const { resultsList } = await customer.recommendations.applyRecommendation(recommendationResourceName)
+        expect(resultsList instanceof Array).toEqual(true)
+        expect(resultsList[0]).toHaveProperty('resourceName')
+    })
+})

--- a/src/tests/recommendation.test.ts
+++ b/src/tests/recommendation.test.ts
@@ -23,9 +23,7 @@ describe('Recommendations', () => {
 
     it('Applies a recommendation', async () => {
         expect.assertions(2)
-        const { resultsList } = await customer.recommendations.applyRecommendation(recommendationResourceName, {
-            validate_only: true,
-        })
+        const { resultsList } = await customer.recommendations.applyRecommendation(recommendationResourceName)
         expect(resultsList instanceof Array).toEqual(true)
         expect(resultsList[0]).toHaveProperty('resourceName')
     })

--- a/src/tests/recommendation.test.ts
+++ b/src/tests/recommendation.test.ts
@@ -23,8 +23,8 @@ describe('Recommendations', () => {
 
     it('Applies a recommendation', async () => {
         expect.assertions(2)
-        const { resultsList } = await customer.recommendations.applyRecommendation(recommendationResourceName)
-        expect(resultsList instanceof Array).toEqual(true)
-        expect(resultsList[0]).toHaveProperty('resourceName')
+        const { results } = await customer.recommendations.applyRecommendation(recommendationResourceName)
+        expect(results instanceof Array).toEqual(true)
+        expect(typeof results[0]).toEqual('string')
     })
 })

--- a/src/tests/recommendation.test.ts
+++ b/src/tests/recommendation.test.ts
@@ -9,7 +9,6 @@ describe('Recommendations', () => {
     it('Lists recommendations', async () => {
         expect.assertions(2)
         const recommendations = await customer.recommendations.list()
-        console.log(recommendations)
         expect(recommendations).toBeInstanceOf(Array)
         expect(typeof recommendations[0].recommendation.resource_name).toEqual('string')
         recommendationResourceName = recommendations[0].recommendation.resource_name as string

--- a/src/tests/recommendation.test.ts
+++ b/src/tests/recommendation.test.ts
@@ -9,6 +9,7 @@ describe('Recommendations', () => {
     it('Lists recommendations', async () => {
         expect.assertions(2)
         const recommendations = await customer.recommendations.list()
+        console.log(recommendations)
         expect(recommendations).toBeInstanceOf(Array)
         expect(typeof recommendations[0].recommendation.resource_name).toEqual('string')
         recommendationResourceName = recommendations[0].recommendation.resource_name as string
@@ -21,10 +22,20 @@ describe('Recommendations', () => {
         expect(typeof recommendation.resource_name).toEqual('string')
     })
 
+    /*
+    These are commented out to make sure no changes are actually made to accounts
+    
     it('Applies a recommendation', async () => {
         expect.assertions(2)
         const { results } = await customer.recommendations.applyRecommendation(recommendationResourceName)
         expect(results instanceof Array).toEqual(true)
         expect(typeof results[0]).toEqual('string')
     })
+
+    it('Dismisses a recommendation', async () => {
+        expect.assertions(2)
+        const { results } = await customer.recommendations.dismissRecommendation(recommendationResourceName)
+        expect(results instanceof Array).toEqual(true)
+        expect(typeof results[0]).toEqual('string')
+    }) */
 })


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a methods to allow users to apply & dismiss recommendations.

*   **What is the current behavior?** (You can also link to an open issue here)
Recommendations can be retrieved but not applied or dismissed.

-   **What is the new behavior (if this is a feature change)?**
You can now apply or dismiss recommendations using the resource name.

*   **Other information**:
Since [ApplyRecommendationRequest](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v2.services#google.ads.googleads.v2.services.ApplyRecommendationRequest) and [DismissRecommendationRequest](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v2.services#google.ads.googleads.v2.services.DismissRecommendationRequest.DismissRecommendationOperation) do not have a validate_only property, the only way to test this method is to actually apply or dismiss the recommendation. The tests are commented out but can do work if they are uncommented. Thanks!