### PR TITLE
Added safe mode to prevent all mutations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
     "prettier.disableLanguages": [],
-    "prettier.eslintIntegration": true,
     "eslint.autoFixOnSave": true
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,7 @@ interface CustomerAuth {
 interface CustomerOptions extends CustomerAuth {
     pre_report_hook?: PreReportHook
     post_report_hook?: PostReportHook
+    prevent_mutations?: boolean
 }
 
 export default class GoogleAdsApi {
@@ -61,6 +62,7 @@ export default class GoogleAdsApi {
         login_customer_id,
         pre_report_hook,
         post_report_hook,
+        prevent_mutations,
     }: CustomerOptions): CustomerInstance {
         if (!customer_account_id || !refresh_token) {
             throw new Error('Must specify {customer_account_id, refresh_token}')
@@ -68,6 +70,7 @@ export default class GoogleAdsApi {
 
         pre_report_hook = pre_report_hook || noop
         post_report_hook = post_report_hook || noop
+        prevent_mutations = prevent_mutations || false
 
         customer_account_id = normaliseCustomerId(customer_account_id)
         login_customer_id = normaliseCustomerId(login_customer_id)
@@ -80,6 +83,13 @@ export default class GoogleAdsApi {
             login_customer_id
         )
 
-        return Customer(customer_account_id, client, this.throttler, pre_report_hook, post_report_hook)
+        return Customer(
+            customer_account_id,
+            client,
+            this.throttler,
+            pre_report_hook,
+            post_report_hook,
+            prevent_mutations
+        )
     }
 }

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -178,9 +178,18 @@ export default function Customer(
     client: GrpcClient,
     throttler: Bottleneck,
     pre_report_hook: PreReportHook,
-    post_report_hook: PostReportHook
+    post_report_hook: PostReportHook,
+    prevent_mutations: boolean
 ): CustomerInstance {
-    const cusService = new CustomerService(cid, client, throttler, 'CustomerService', pre_report_hook, post_report_hook)
+    const cusService = new CustomerService(
+        cid,
+        client,
+        throttler,
+        'CustomerService',
+        pre_report_hook,
+        post_report_hook,
+        prevent_mutations
+    )
 
     return {
         /* Top level customer methods */
@@ -192,139 +201,271 @@ export default function Customer(
         mutateResources: (operations, options) => cusService.mutateResources(operations, options),
 
         /* Services */
-        campaigns: new CampaignService(cid, client, throttler, 'CampaignService'),
-        campaignBudgets: new CampaignBudgetService(cid, client, throttler, 'CampaignBudgetService'),
-        adGroups: new AdGroupService(cid, client, throttler, 'AdGroupService'),
+        campaigns: new CampaignService(cid, client, throttler, 'CampaignService', prevent_mutations),
+        campaignBudgets: new CampaignBudgetService(cid, client, throttler, 'CampaignBudgetService', prevent_mutations),
+        adGroups: new AdGroupService(cid, client, throttler, 'AdGroupService', prevent_mutations),
         accountBudgetProposals: new AccountBudgetProposalService(
             cid,
             client,
             throttler,
-            'AccountBudgetProposalService'
+            'AccountBudgetProposalService',
+            prevent_mutations
         ),
-        accountBudgets: new AccountBudgetService(cid, client, throttler, 'AccountBudgetService'),
-        ads: new AdService(cid, client, throttler, 'AdService'),
-        adGroupAdLabels: new AdGroupAdLabelService(cid, client, throttler, 'AdGroupAdLabelService'),
-        adGroupAds: new AdGroupAdService(cid, client, throttler, 'AdGroupAdService'),
-        adGroupBidModifiers: new AdGroupBidModifierService(cid, client, throttler, 'AdGroupBidModifierService'),
+        accountBudgets: new AccountBudgetService(cid, client, throttler, 'AccountBudgetService', prevent_mutations),
+        ads: new AdService(cid, client, throttler, 'AdService', prevent_mutations),
+        adGroupAdLabels: new AdGroupAdLabelService(cid, client, throttler, 'AdGroupAdLabelService', prevent_mutations),
+        adGroupAds: new AdGroupAdService(cid, client, throttler, 'AdGroupAdService', prevent_mutations),
+        adGroupBidModifiers: new AdGroupBidModifierService(
+            cid,
+            client,
+            throttler,
+            'AdGroupBidModifierService',
+            prevent_mutations
+        ),
         adGroupCriterionLabels: new AdGroupCriterionLabelService(
             cid,
             client,
             throttler,
-            'AdGroupCriterionLabelService'
+            'AdGroupCriterionLabelService',
+            prevent_mutations
         ),
-        adGroupCriteria: new AdGroupCriterionService(cid, client, throttler, 'AdGroupCriterionService'),
+        adGroupCriteria: new AdGroupCriterionService(
+            cid,
+            client,
+            throttler,
+            'AdGroupCriterionService',
+            prevent_mutations
+        ),
         adGroupExtensionSettings: new AdGroupExtensionSettingService(
             cid,
             client,
             throttler,
-            'AdGroupExtensionSettingService'
+            'AdGroupExtensionSettingService',
+            prevent_mutations
         ),
-        adGroupFeeds: new AdGroupFeedService(cid, client, throttler, 'AdGroupFeedService'),
-        adGroupLabels: new AdGroupLabelService(cid, client, throttler, 'AdGroupLabelService'),
-        assets: new AssetService(cid, client, throttler, 'AssetService'),
-        biddingStrategies: new BiddingStrategyService(cid, client, throttler, 'BiddingStrategyService'),
-        billingSetups: new BillingSetupService(cid, client, throttler, 'BillingSetupService'),
-        campaignBidModifiers: new CampaignBidModifierService(cid, client, throttler, 'CampaignBidModifierService'),
-        campaignCriteria: new CampaignCriterionService(cid, client, throttler, 'CampaignCriterionService'),
+        adGroupFeeds: new AdGroupFeedService(cid, client, throttler, 'AdGroupFeedService', prevent_mutations),
+        adGroupLabels: new AdGroupLabelService(cid, client, throttler, 'AdGroupLabelService', prevent_mutations),
+        assets: new AssetService(cid, client, throttler, 'AssetService', prevent_mutations),
+        biddingStrategies: new BiddingStrategyService(
+            cid,
+            client,
+            throttler,
+            'BiddingStrategyService',
+            prevent_mutations
+        ),
+        billingSetups: new BillingSetupService(cid, client, throttler, 'BillingSetupService', prevent_mutations),
+        campaignBidModifiers: new CampaignBidModifierService(
+            cid,
+            client,
+            throttler,
+            'CampaignBidModifierService',
+            prevent_mutations
+        ),
+        campaignCriteria: new CampaignCriterionService(
+            cid,
+            client,
+            throttler,
+            'CampaignCriterionService',
+            prevent_mutations
+        ),
         campaignExtensionSettings: new CampaignExtensionSettingService(
             cid,
             client,
             throttler,
-            'CampaignExtensionSettingService'
+            'CampaignExtensionSettingService',
+            prevent_mutations
         ),
-        campaignFeeds: new CampaignFeedService(cid, client, throttler, 'CampaignFeedService'),
-        campaignLabels: new CampaignLabelService(cid, client, throttler, 'CampaignLabelService'),
-        campaignSharedSets: new CampaignSharedSetService(cid, client, throttler, 'CampaignSharedSetService'),
-        carrierConstants: new CarrierConstantService(cid, client, throttler, 'CarrierConstantService'),
-        changeStatus: new ChangeStatusService(cid, client, throttler, 'ChangeStatusService'),
-        conversionActions: new ConversionActionService(cid, client, throttler, 'ConversionActionService'),
-        conversionUploads: new ConversionUploadService(cid, client, throttler, 'ConversionUploadService'),
+        campaignFeeds: new CampaignFeedService(cid, client, throttler, 'CampaignFeedService', prevent_mutations),
+        campaignLabels: new CampaignLabelService(cid, client, throttler, 'CampaignLabelService', prevent_mutations),
+        campaignSharedSets: new CampaignSharedSetService(
+            cid,
+            client,
+            throttler,
+            'CampaignSharedSetService',
+            prevent_mutations
+        ),
+        carrierConstants: new CarrierConstantService(
+            cid,
+            client,
+            throttler,
+            'CarrierConstantService',
+            prevent_mutations
+        ),
+        changeStatus: new ChangeStatusService(cid, client, throttler, 'ChangeStatusService', prevent_mutations),
+        conversionActions: new ConversionActionService(
+            cid,
+            client,
+            throttler,
+            'ConversionActionService',
+            prevent_mutations
+        ),
+        conversionUploads: new ConversionUploadService(
+            cid,
+            client,
+            throttler,
+            'ConversionUploadService',
+            prevent_mutations
+        ),
         // conversionAdjustmentUploads: new ConversionAdjustmentUploadService(
         //     cid,
         //     client,
         //     throttler,
         //     'ConversionAdjustmentUploadService'
         // ),
-        customInterests: new CustomInterestService(cid, client, throttler, 'CustomInterestService'),
-        customerClientLinks: new CustomerClientLinkService(cid, client, throttler, 'CustomerClientLinkService'),
-        customerClients: new CustomerClientService(cid, client, throttler, 'CustomerClientService'),
+        customInterests: new CustomInterestService(cid, client, throttler, 'CustomInterestService', prevent_mutations),
+        customerClientLinks: new CustomerClientLinkService(
+            cid,
+            client,
+            throttler,
+            'CustomerClientLinkService',
+            prevent_mutations
+        ),
+        customerClients: new CustomerClientService(cid, client, throttler, 'CustomerClientService', prevent_mutations),
         customerExtensionSettings: new CustomerExtensionSettingService(
             cid,
             client,
             throttler,
-            'CustomerExtensionSettingService'
+            'CustomerExtensionSettingService',
+            prevent_mutations
         ),
-        customerFeeds: new CustomerFeedService(cid, client, throttler, 'CustomerFeedService'),
-        customerLabels: new CustomerLabelService(cid, client, throttler, 'CustomerLabelService'),
-        customerManagerLinks: new CustomerManagerLinkService(cid, client, throttler, 'CustomerManagerLinkService'),
+        customerFeeds: new CustomerFeedService(cid, client, throttler, 'CustomerFeedService', prevent_mutations),
+        customerLabels: new CustomerLabelService(cid, client, throttler, 'CustomerLabelService', prevent_mutations),
+        customerManagerLinks: new CustomerManagerLinkService(
+            cid,
+            client,
+            throttler,
+            'CustomerManagerLinkService',
+            prevent_mutations
+        ),
         customerNegativeCriteria: new CustomerNegativeCriterionService(
             cid,
             client,
             throttler,
-            'CustomerNegativeCriterionService'
+            'CustomerNegativeCriterionService',
+            prevent_mutations
         ),
-        domainCategories: new DomainCategoryService(cid, client, throttler, 'DomainCategoryService'),
-        extensionFeedItems: new ExtensionFeedItemService(cid, client, throttler, 'ExtensionFeedItemService'),
-        feedItems: new FeedItemService(cid, client, throttler, 'FeedItemService'),
-        feedItemTargets: new FeedItemTargetService(cid, client, throttler, 'FeedItemTargetService'),
-        feedMappings: new FeedMappingService(cid, client, throttler, 'FeedMappingService'),
-        feeds: new FeedService(cid, client, throttler, 'FeedService'),
-        geoTargetConstants: new GeoTargetConstantService(cid, client, throttler, 'GeoTargetConstantService'),
-        keywordPlanAdGroups: new KeywordPlanAdGroupService(cid, client, throttler, 'KeywordPlanAdGroupService'),
-        keywordPlanCampaigns: new KeywordPlanCampaignService(cid, client, throttler, 'KeywordPlanCampaignService'),
+        domainCategories: new DomainCategoryService(cid, client, throttler, 'DomainCategoryService', prevent_mutations),
+        extensionFeedItems: new ExtensionFeedItemService(
+            cid,
+            client,
+            throttler,
+            'ExtensionFeedItemService',
+            prevent_mutations
+        ),
+        feedItems: new FeedItemService(cid, client, throttler, 'FeedItemService', prevent_mutations),
+        feedItemTargets: new FeedItemTargetService(cid, client, throttler, 'FeedItemTargetService', prevent_mutations),
+        feedMappings: new FeedMappingService(cid, client, throttler, 'FeedMappingService', prevent_mutations),
+        feeds: new FeedService(cid, client, throttler, 'FeedService', prevent_mutations),
+        geoTargetConstants: new GeoTargetConstantService(
+            cid,
+            client,
+            throttler,
+            'GeoTargetConstantService',
+            prevent_mutations
+        ),
+        keywordPlanAdGroups: new KeywordPlanAdGroupService(
+            cid,
+            client,
+            throttler,
+            'KeywordPlanAdGroupService',
+            prevent_mutations
+        ),
+        keywordPlanCampaigns: new KeywordPlanCampaignService(
+            cid,
+            client,
+            throttler,
+            'KeywordPlanCampaignService',
+            prevent_mutations
+        ),
         // keywordPlanIdeas: new KeywordPlanIdeaService(cid, client, throttler, 'KeywordPlanIdeaService'),
-        keywordPlanKeywords: new KeywordPlanKeywordService(cid, client, throttler, 'KeywordPlanKeywordService'),
+        keywordPlanKeywords: new KeywordPlanKeywordService(
+            cid,
+            client,
+            throttler,
+            'KeywordPlanKeywordService',
+            prevent_mutations
+        ),
         keywordPlanNegativeKeywords: new KeywordPlanNegativeKeywordService(
             cid,
             client,
             throttler,
-            'KeywordPlanNegativeKeywordService'
+            'KeywordPlanNegativeKeywordService',
+            prevent_mutations
         ),
-        keywordPlans: new KeywordPlanService(cid, client, throttler, 'KeywordPlanService'),
-        labels: new LabelService(cid, client, throttler, 'LabelService'),
-        languageConstants: new LanguageConstantService(cid, client, throttler, 'LanguageConstantService'),
-        mediaFiles: new MediaFileService(cid, client, throttler, 'MediaFileService'),
+        keywordPlans: new KeywordPlanService(cid, client, throttler, 'KeywordPlanService', prevent_mutations),
+        labels: new LabelService(cid, client, throttler, 'LabelService', prevent_mutations),
+        languageConstants: new LanguageConstantService(
+            cid,
+            client,
+            throttler,
+            'LanguageConstantService',
+            prevent_mutations
+        ),
+        mediaFiles: new MediaFileService(cid, client, throttler, 'MediaFileService', prevent_mutations),
         // merchantCenterLinks: new MerchantCenterLinkService(cid, client, throttler, 'MerchantCenterLinkService'),
         mobileAppCategoryConstants: new MobileAppCategoryConstantService(
             cid,
             client,
             throttler,
-            'MobileAppCategoryConstantService'
+            'MobileAppCategoryConstantService',
+            prevent_mutations
         ),
-        mobileDeviceConstants: new MobileDeviceConstantService(cid, client, throttler, 'MobileDeviceConstantService'),
+        mobileDeviceConstants: new MobileDeviceConstantService(
+            cid,
+            client,
+            throttler,
+            'MobileDeviceConstantService',
+            prevent_mutations
+        ),
         operatingSystemVersionConstants: new OperatingSystemVersionConstantService(
             cid,
             client,
             throttler,
-            'OperatingSystemVersionConstantService'
+            'OperatingSystemVersionConstantService',
+            prevent_mutations
         ),
         // paymentsAccounts: new PaymentsAccountService(cid, client, throttler, 'PaymentsAccountService'),
         productBiddingCategoryConstants: new ProductBiddingCategoryConstantService(
             cid,
             client,
             throttler,
-            'ProductBiddingCategoryConstantService'
+            'ProductBiddingCategoryConstantService',
+            prevent_mutations
         ),
-        recommendations: new RecommendationService(cid, client, throttler, 'RecommendationService'),
-        remarketingActions: new RemarketingActionService(cid, client, throttler, 'RemarketingActionService'),
-        sharedCriteria: new SharedCriterionService(cid, client, throttler, 'SharedCriterionService'),
-        sharedSets: new SharedSetService(cid, client, throttler, 'SharedSetService'),
-        topicConstants: new TopicConstantService(cid, client, throttler, 'TopicConstantService'),
-        userInterests: new UserInterestService(cid, client, throttler, 'UserInterestService'),
-        userLists: new UserListService(cid, client, throttler, 'UserListService'),
-        videos: new VideoService(cid, client, throttler, 'VideoService'),
-        adGroupSimulations: new AdGroupSimulationService(cid, client, throttler, 'AdGroupSimulationService'),
+        recommendations: new RecommendationService(cid, client, throttler, 'RecommendationService', prevent_mutations),
+        remarketingActions: new RemarketingActionService(
+            cid,
+            client,
+            throttler,
+            'RemarketingActionService',
+            prevent_mutations
+        ),
+        sharedCriteria: new SharedCriterionService(cid, client, throttler, 'SharedCriterionService', prevent_mutations),
+        sharedSets: new SharedSetService(cid, client, throttler, 'SharedSetService', prevent_mutations),
+        topicConstants: new TopicConstantService(cid, client, throttler, 'TopicConstantService', prevent_mutations),
+        userInterests: new UserInterestService(cid, client, throttler, 'UserInterestService', prevent_mutations),
+        userLists: new UserListService(cid, client, throttler, 'UserListService', prevent_mutations),
+        videos: new VideoService(cid, client, throttler, 'VideoService', prevent_mutations),
+        adGroupSimulations: new AdGroupSimulationService(
+            cid,
+            client,
+            throttler,
+            'AdGroupSimulationService',
+            prevent_mutations
+        ),
         adGroupCriterionSimulations: new AdGroupCriterionSimulationService(
             cid,
             client,
             throttler,
-            'AdGroupCriterionSimulationService'
+            'AdGroupCriterionSimulationService',
+            prevent_mutations
         ),
         campaignCriterionSimulations: new CampaignCriterionSimulationService(
             cid,
             client,
             throttler,
-            'CampaignCriterionSimulationService'
+            'CampaignCriterionSimulationService',
+            prevent_mutations
         ),
     }
 }

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -27,9 +27,10 @@ export default class CustomerService extends Service {
         throttler: Bottleneck,
         name: string,
         pre_report_hook: PreReportHook,
-        post_report_hook: PostReportHook
+        post_report_hook: PostReportHook,
+        prevent_mutations: boolean
     ) {
-        super(cid, client, throttler, name)
+        super(cid, client, throttler, name, prevent_mutations)
 
         this.pre_report_hook = pre_report_hook
         this.post_report_hook = post_report_hook
@@ -82,6 +83,11 @@ export default class CustomerService extends Service {
             request.setValidateOnly(options.validate_only as boolean)
         }
 
+        // Make all requests immutable if prevent_mutations is enabled
+        if (this.prevent_mutations) {
+            request.setValidateOnly(true)
+        }
+
         await this.service.mutateCustomer(request)
     }
 
@@ -101,6 +107,11 @@ export default class CustomerService extends Service {
         }
         if (options && options.hasOwnProperty('partial_failure')) {
             request.setPartialFailure(options.partial_failure as boolean)
+        }
+
+        // Make all requests immutable if prevent_mutations is enabled
+        if (this.prevent_mutations) {
+            request.setValidateOnly(true)
         }
 
         const ops: Array<grpc.MutateOperation> = []

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -46,6 +46,20 @@ export function newMccCustomer() {
     })
 }
 
+export function newImmutableCustomer() {
+    const client = new GoogleAdsApi({
+        client_id: process.env.GADS_CLIENT_ID as string,
+        client_secret: process.env.GADS_CLIENT_SECRET as string,
+        developer_token: process.env.GADS_DEVELOPER_TOKEN as string,
+    })
+    return client.Customer({
+        customer_account_id: process.env.GADS_CID as string,
+        login_customer_id: process.env.GADS_LOGIN_CUSTOMER_ID as string,
+        refresh_token: process.env.GADS_REFRESH_TOKEN as string,
+        prevent_mutations: true,
+    })
+}
+
 export function getRandomName(entity: string) {
     return `test-${entity}-${(Math.random() * 100000 + 1).toFixed(0)}`
 }


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a new client option `preventMutations`, which works as a safe mode to stop accidental Google Ads mutations. This works well for development environments.

*   **What is the current behavior?** (You can also link to an open issue here)
Currently there is no option for this type of behaviour.

-   **What is the new behavior (if this is a feature change)?**
If `preventMutations` is enabled, all mutable requests will set `validate_only` to `true`.

*   **Other information**:
I've also included some new tests at the customer & service level.
