### PR TITLE
Support for prevent mutations & logging from google-ads-node

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
     "prettier.disableLanguages": [],
-    "prettier.eslintIntegration": true,
     "eslint.autoFixOnSave": true
 }

--- a/package.json
+++ b/package.json
@@ -67,14 +67,14 @@
         "prettier": "^1.17.1",
         "showdown": "^1.9.0",
         "standard-version": "^5.0.2",
-        "ts-jest": "^24.0.0",
+        "ts-jest": "^24.1.0",
         "tslint": "^5.12.1",
         "turndown": "^5.0.3",
-        "typescript": "^3.3.1"
+        "typescript": "^3.7.2"
     },
     "dependencies": {
         "bottleneck": "^2.16.1",
-        "google-ads-node": "^1.13.9",
+        "google-ads-node": "^1.14.0",
         "lodash": "^4.17.15",
         "redis": "^2.8.0",
         "request": "^2.88.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 import { noop } from 'lodash'
 
 import Customer, { CustomerInstance } from './customer'
-import GrpcClient from './grpc'
+import GrpcClient, { GoogleAdsNodeOptions } from './grpc'
 import { normaliseCustomerId } from './utils'
 import { PreReportHook, PostReportHook } from './types'
 
@@ -23,6 +23,7 @@ interface CustomerAuth {
 interface CustomerOptions extends CustomerAuth {
     pre_report_hook?: PreReportHook
     post_report_hook?: PostReportHook
+    gads_node_options?: GoogleAdsNodeOptions
 }
 
 export default class GoogleAdsApi {
@@ -61,6 +62,7 @@ export default class GoogleAdsApi {
         login_customer_id,
         pre_report_hook,
         post_report_hook,
+        gads_node_options,
     }: CustomerOptions): CustomerInstance {
         if (!customer_account_id || !refresh_token) {
             throw new Error('Must specify {customer_account_id, refresh_token}')
@@ -77,7 +79,8 @@ export default class GoogleAdsApi {
             this.options.client_id,
             this.options.client_secret,
             refresh_token as string,
-            login_customer_id
+            login_customer_id,
+            gads_node_options
         )
 
         return Customer(customer_account_id, client, this.throttler, pre_report_hook, post_report_hook)

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,10 +20,9 @@ interface CustomerAuth {
     login_customer_id?: string
 }
 
-interface CustomerOptions extends CustomerAuth {
+interface CustomerOptions extends CustomerAuth, GoogleAdsNodeOptions {
     pre_report_hook?: PreReportHook
     post_report_hook?: PostReportHook
-    gads_node_options?: GoogleAdsNodeOptions
 }
 
 export default class GoogleAdsApi {
@@ -62,7 +61,8 @@ export default class GoogleAdsApi {
         login_customer_id,
         pre_report_hook,
         post_report_hook,
-        gads_node_options,
+        prevent_mutations,
+        logging,
     }: CustomerOptions): CustomerInstance {
         if (!customer_account_id || !refresh_token) {
             throw new Error('Must specify {customer_account_id, refresh_token}')
@@ -73,6 +73,11 @@ export default class GoogleAdsApi {
 
         customer_account_id = normaliseCustomerId(customer_account_id)
         login_customer_id = normaliseCustomerId(login_customer_id)
+
+        const gads_node_options = {
+            prevent_mutations,
+            logging,
+        }
 
         const client = new GrpcClient(
             this.options.developer_token,

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -21,8 +21,8 @@ export default class GrpcClient {
         client_id: string,
         client_secret: string,
         refresh_token: string,
-        login_customer_id?: string,
-        gads_node_options?: GoogleAdsNodeOptions
+        login_customer_id: string,
+        gads_node_options: GoogleAdsNodeOptions
     ) {
 
         const additional_options: any = {}

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -1,4 +1,4 @@
-import { GoogleAdsClient, SearchGoogleAdsRequest } from 'google-ads-node'
+import { GoogleAdsClient, SearchGoogleAdsRequest, LogOptions } from 'google-ads-node'
 import Bottleneck from 'bottleneck'
 
 import { getAccessToken } from './token'
@@ -6,6 +6,11 @@ import { getAccessToken } from './token'
 interface BuildSearchRequestResponse {
     request: SearchGoogleAdsRequest
     limit: number
+}
+
+export interface GoogleAdsNodeOptions {
+    prevent_mutations?: boolean
+    logging?: LogOptions
 }
 
 export default class GrpcClient {
@@ -16,8 +21,20 @@ export default class GrpcClient {
         client_id: string,
         client_secret: string,
         refresh_token: string,
-        login_customer_id?: string
+        login_customer_id?: string,
+        gads_node_options?: GoogleAdsNodeOptions
     ) {
+
+        const additional_options: any = {}
+
+        // Apply google-ads-node options if specified
+        if(gads_node_options?.prevent_mutations) {
+            additional_options.preventMutations = gads_node_options.prevent_mutations
+        }
+        if(gads_node_options?.logging) {
+            additional_options.logging = gads_node_options.logging
+        }
+
         this.client = new GoogleAdsClient({
             developer_token,
             client_id,
@@ -32,6 +49,7 @@ export default class GrpcClient {
                     refresh_token: refreshToken,
                 })
             },
+            ...additional_options
         })
     }
 

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -57,7 +57,7 @@ export function newCustomerWithNodeOptions(options: GoogleAdsNodeOptions) {
         customer_account_id: process.env.GADS_CID as string,
         login_customer_id: process.env.GADS_LOGIN_CUSTOMER_ID as string,
         refresh_token: process.env.GADS_REFRESH_TOKEN as string,
-        gads_node_options: options,
+        ...options,
     })
 }
 

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -1,4 +1,5 @@
 import { GoogleAdsApi } from './index'
+import { GoogleAdsNodeOptions } from './grpc'
 
 export const CID = process.env.GADS_CID as string
 export const CID_WITH_METRICS = process.env.GADS_CID_WITH_METRICS as string
@@ -43,6 +44,20 @@ export function newMccCustomer() {
         customer_account_id: process.env.GADS_LOGIN_CUSTOMER_ID as string,
         login_customer_id: process.env.GADS_LOGIN_CUSTOMER_ID as string,
         refresh_token: process.env.GADS_REFRESH_TOKEN as string,
+    })
+}
+
+export function newCustomerWithNodeOptions(options: GoogleAdsNodeOptions) {
+    const client = new GoogleAdsApi({
+        client_id: process.env.GADS_CLIENT_ID as string,
+        client_secret: process.env.GADS_CLIENT_SECRET as string,
+        developer_token: process.env.GADS_DEVELOPER_TOKEN as string,
+    })
+    return client.Customer({
+        customer_account_id: process.env.GADS_CID as string,
+        login_customer_id: process.env.GADS_LOGIN_CUSTOMER_ID as string,
+        refresh_token: process.env.GADS_REFRESH_TOKEN as string,
+        gads_node_options: options,
     })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -458,7 +458,12 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@^4.14.112":
+"@types/lodash@*":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/lodash@^4.14.112":
   version "4.14.138"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
   integrity sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==
@@ -474,9 +479,9 @@
   integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
 "@types/node@^10.1.0":
-  version "10.14.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.16.tgz#4d690c96cbb7b2728afea0e260d680501b3da5cf"
-  integrity sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==
+  version "10.17.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.5.tgz#c1920150f7b90708a7d0f3add12a06bc9123c055"
+  integrity sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==
 
 "@types/protobufjs@^6.0.0":
   version "6.0.0"
@@ -1993,7 +1998,19 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.5:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -2010,10 +2027,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-google-ads-node@^1.13.9:
-  version "1.13.9"
-  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.13.9.tgz#9247b42490331747e587c895c1278c0c3d377436"
-  integrity sha512-Njk77RhFPXQDElkePOcKt1KBXKiPvR5AstD7BNYpDc273P1mqjaVn+hTrl6BHcy4HnZMQgETofXchZb4NLAI7Q==
+google-ads-node@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.14.0.tgz#cb5443049dd191ac620746d72585ec62aa45106a"
+  integrity sha512-KFRHKqPnSG1GMyxnHDOreJ5sXcNAQV4JmzB3p4Mt5uHjwl0w1Lh0h/E0SHoRVxdaFBuMG0B//psC8l8zOtrz7g==
   dependencies:
     "@types/cosmiconfig" "^5.0.3"
     "@types/google-protobuf" "^3.2.7"
@@ -2056,9 +2073,9 @@ google-p12-pem@^1.0.0:
     pify "^4.0.0"
 
 google-protobuf@^3.8.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.9.1.tgz#87e6a16b7fb16405b515a6c6622d5ace45578d86"
-  integrity sha512-tkz7SVwBktFbqFK3teXFUY/VM57+mbUgV9bSD+sZH1ocHJ7uk7BfEWMRdU24dd0ciUDokreA7ghH2fYFIczQdw==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.10.0.tgz#f36171128090615049f9b0e42252b1a10a4bc534"
+  integrity sha512-d0cMO8TJ6xtB/WrVHCv5U81L2ulX+aCD58IljyAN6mHwdHHJ2jbcauX5glvivi3s3hx7EYEo7eUA9WftzamMnw==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.2"
@@ -2071,15 +2088,15 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 grpc@^1.21.1:
-  version "1.23.3"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.23.3.tgz#30a013ca2cd7e350b0ffc0034be5380ddef3ae7f"
-  integrity sha512-7vdzxPw9s5UYch4aUn4hyM5tMaouaxUUkwkgJlwbR4AXMxiYZJOv19N2ps2eKiuUbJovo5fnGF9hg/X91gWYjw==
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.2.tgz#76d047bfa7b05b607cbbe3abb99065dcefe0c099"
+  integrity sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==
   dependencies:
     "@types/bytebuffer" "^5.0.40"
     lodash.camelcase "^4.3.0"
     lodash.clone "^4.5.0"
     nan "^2.13.2"
-    node-pre-gyp "^0.13.0"
+    node-pre-gyp "^0.14.0"
     protobufjs "^5.0.3"
 
 gtoken@^2.3.2:
@@ -2192,9 +2209,9 @@ http-signature@~1.2.0:
     sshpk "^1.7.0"
 
 https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
+  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
@@ -2982,7 +2999,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.0:
+json5@2.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  dependencies:
+    minimist "^1.2.0"
+
+json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
@@ -3150,6 +3174,11 @@ lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
+
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -3416,6 +3445,14 @@ minipass@^2.2.1, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.8.6:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
@@ -3546,10 +3583,10 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pre-gyp@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
-  integrity sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==
+node-pre-gyp@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -3560,7 +3597,7 @@ node-pre-gyp@^0.13.0:
     rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^4"
+    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -4760,6 +4797,19 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+tar@^4.4.2:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
 test-exclude@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
@@ -4878,15 +4928,16 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-jest@^24.0.0:
-  version "24.0.2"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
-  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+ts-jest@^24.1.0:
+  version "24.1.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.1.0.tgz#2eaa813271a2987b7e6c3fefbda196301c131734"
+  integrity sha512-HEGfrIEAZKfu1pkaxB9au17b1d9b56YZSqz5eCVE8mX68+5reOvlM93xGOzzCREIov9mdH7JBG+s0UyNAqr0tQ==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"
     json5 "2.x"
+    lodash.memoize "4.x"
     make-error "1.x"
     mkdirp "0.x"
     resolve "1.x"
@@ -4955,10 +5006,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -5189,10 +5240,15 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@10.x:
   version "10.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,9 +394,9 @@
     "@types/node" "*"
 
 "@types/google-protobuf@^3.2.7":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.7.1.tgz#69503856e717a4ed2fd0216d4aa3f0bebf5df5df"
-  integrity sha512-kiLxbqoi2C7NmkGj1ZpkSDyIqj4vqDEIjx7wX+O0GXV6bLX6u/oLz49CwefD0c0vzaKeBdOqmUtI8bC0bBRr0w==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.7.2.tgz#cd8a360c193ce4d672575a20a79f49ba036d38d2"
+  integrity sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This introduces new options to the `Customer` instance, allowing support for [prevent mutations](https://github.com/opteo/google-ads-node#safe-mode) and [logging](https://github.com/opteo/google-ads-node#logging). Two new useful features from our google-ads-node library.

Also, typescript has been upgraded so we can use optional chaining 🎉 

*   **What is the current behavior?** (You can also link to an open issue here)
Currently there is no support for these options.

-   **What is the new behavior (if this is a feature change)?**
The new fields are `prevent_mutations` and `logging`. Details of these settings can be found in [google-ads-node](https://github.com/opteo/google-ads-node#client-options).

An example with all settings used is shown below.
```typescript
const cus = client.Customer({
    customer_account_id: process.env.GADS_CID,
    login_customer_id: process.env.GADS_LOGIN_CUSTOMER_ID,
    refresh_token: process.env.GADS_REFRESH_TOKEN,
    prevent_mutations: true,
    logging: {
        output: 'none',
        verbosity: 'info',
        callback(message) {
            console.log(message)
        },
    },
})
```

*   **Other information**:
I assumed this made more sense at the customer level (specifically for our internal use cases), but perhaps it should be global at the client level? 