### PR TITLE
Added 3 fields to types.ts 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,11 @@ export interface ReportOptions {
         | fields.AdGroupBidModifierFields
         | fields.AdGroupCriterionFields
         | fields.AdGroupCriterionLabelFields
+        | fields.AdGroupCriterionSimulationFields
         | fields.AdGroupExtensionSettingFields
         | fields.AdGroupFeedFields
         | fields.AdGroupLabelFields
+        | fields.AdGroupSimulationFields
         | fields.AdScheduleViewFields
         | fields.AgeRangeViewFields
         | fields.AssetFields
@@ -25,6 +27,7 @@ export interface ReportOptions {
         | fields.CampaignBidModifierFields
         | fields.CampaignBudgetFields
         | fields.CampaignCriterionFields
+        | fields.CampaignCriterionSimulationFields
         | fields.CampaignExtensionSettingFields
         | fields.CampaignFeedFields
         | fields.CampaignLabelFields


### PR DESCRIPTION
The new version of typescript is more strict, which causes some errors when using any kind of bid simulation. 

The fields are 
 - `AdGroupCriterionSimulationFields`
 - `AdGroupSimulationFields`
 - `CampaignCriterionSimulationFields`

These are direct imports from `google-ads-node`. 