### PR TITLE
feat(generics): Adding generics to report on customer instance

### DIFF
--- a/src/customer.ts
+++ b/src/customer.ts
@@ -94,7 +94,7 @@ import { ReportOptions, ServiceCreateOptions, PostReportHook, PreReportHook, Mut
 
 export interface CustomerInstance {
     /* Global customer methods */
-    report: <T = any>(options: ReportOptions) => ReportResponse<T>
+    report: <T = any[]>(options: ReportOptions) => ReportResponse<T>
     query: (qry: string) => QueryResponse
     list: () => ListResponse
     get: (id: number | string) => GetResponse

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -94,7 +94,7 @@ import { ReportOptions, ServiceCreateOptions, PostReportHook, PreReportHook, Mut
 
 export interface CustomerInstance {
     /* Global customer methods */
-    report: (options: ReportOptions) => ReportResponse
+    report: <T = any>(options: ReportOptions) => ReportResponse<T>
     query: (qry: string) => QueryResponse
     list: () => ListResponse
     get: (id: number | string) => GetResponse

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -10,7 +10,7 @@ import Bottleneck from 'bottleneck'
 import Service, { Mutation } from './service'
 import { ReportOptions, ServiceCreateOptions, PreReportHook, PostReportHook, MutateResourceOperation } from '../types'
 
-export type ReportResponse = Promise<Array<any>>
+export type ReportResponse<T> = Promise<Array<T>>
 export type QueryResponse = Promise<Array<any>>
 export type ListResponse = Promise<Array<{ customer: Customer }>>
 export type GetResponse = Promise<Customer>
@@ -35,7 +35,7 @@ export default class CustomerService extends Service {
         this.post_report_hook = post_report_hook
     }
 
-    public async report(options: ReportOptions): ReportResponse {
+    public async report<T>(options: ReportOptions): ReportResponse<T> {
         const results = await this.serviceReport(options, this.pre_report_hook, this.post_report_hook)
         return results
     }

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -10,7 +10,7 @@ import Bottleneck from 'bottleneck'
 import Service, { Mutation } from './service'
 import { ReportOptions, ServiceCreateOptions, PreReportHook, PostReportHook, MutateResourceOperation } from '../types'
 
-export type ReportResponse<T> = Promise<Array<T>>
+export type ReportResponse<T> = Promise<T>
 export type QueryResponse = Promise<Array<any>>
 export type ListResponse = Promise<Array<{ customer: Customer }>>
 export type GetResponse = Promise<Customer>

--- a/src/tests/customer.test.ts
+++ b/src/tests/customer.test.ts
@@ -62,7 +62,7 @@ describe('customer', () => {
                 }
             }
 
-            await customer.report<Campaign>({
+            await customer.report<Campaign[]>({
                 entity: 'campaign',
                 attributes: ['campaign.name'],
                 limit: 5,

--- a/src/tests/customer.test.ts
+++ b/src/tests/customer.test.ts
@@ -53,6 +53,23 @@ describe('customer', () => {
             )
         })
 
+        // fairly useless test as it will always pass, just used to checkout the generics functionality
+        it('retrieves data using a generic', async () => {
+            interface Campaign {
+                campaign: {
+                    resource_name: string,
+                    name: string
+                }
+            }
+
+            await customer.report<Campaign>({
+                entity: 'campaign',
+                attributes: ['campaign.name'],
+                limit: 5,
+            })
+            expect(true)
+        })
+
         it('retrieves data when using segments', async () => {
             const ad_group = await customer.report({
                 entity: 'ad_group',


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- This allows generics to be used on the report method within the customer instance

*   **What is the current behavior?** (You can also link to an open issue here)
- No generics

-   **What is the new behavior (if this is a feature change)?**
- Can now **optionally** use generics. No change of current report behaviour if no generics are used (will default to any[])

*   **Other information**:
