### PR TITLE
feat(conversion_upload): Adding conversion upload service

### DIFF
--- a/src/services/conversion_upload.ts
+++ b/src/services/conversion_upload.ts
@@ -1,19 +1,60 @@
-import { CallConversion, ClickConversion } from 'google-ads-node/build/lib/resources'
+import {
+    CallConversion,
+    ClickConversion,
+    UploadCallConversionsResponse,
+    UploadClickConversionsResponse,
+} from 'google-ads-node/build/lib/resources'
+import * as grpc from 'google-ads-node'
 
 import Service from './service'
+import { ServiceCreateOptions } from '../types'
 
 export default class ConversionAdjustmentUploadService extends Service {
-    public async uploadCallConversion(conversion: CallConversion): Promise<any> {
-        const pb = this.buildResource('UploadCallConversionsRequest', conversion)
-        const response = await this.service.uploadConversionAdjustments(pb)
-        const parsed = this.parseServiceResults(response)
-        return parsed
+    public async uploadCallConversions(
+        conversions: CallConversion[],
+        options?: ServiceCreateOptions
+    ): Promise<UploadCallConversionsResponse> {
+        const protobufs = this.buildResources('CallConversion', conversions) as Array<grpc.CallConversion>
+
+        const request = new grpc.UploadCallConversionsRequest()
+
+        request.setCustomerId(this.cid)
+
+        request.setConversionsList(protobufs)
+
+        if (options?.validate_only) {
+            request.setValidateOnly(options.validate_only)
+        }
+
+        if (options?.partial_failure) {
+            request.setPartialFailure(options.partial_failure)
+        }
+
+        const response = await this.serviceCall('uploadCallConversions', request, true)
+        return response
     }
 
-    public async uploadClickConversion(conversion: ClickConversion): Promise<any> {
-        const pb = this.buildResource('UploadClickConversionsRequest', conversion)
-        const response = await this.service.uploadConversionAdjustments(pb)
-        const parsed = this.parseServiceResults(response)
-        return parsed
+    public async uploadClickConversions(
+        conversions: ClickConversion[],
+        options?: ServiceCreateOptions
+    ): Promise<UploadClickConversionsResponse> {
+        const protobufs = this.buildResources('ClickConversion', conversions) as Array<grpc.ClickConversion>
+
+        const request = new grpc.UploadClickConversionsRequest()
+
+        request.setCustomerId(this.cid)
+
+        request.setConversionsList(protobufs)
+
+        if (options?.validate_only) {
+            request.setValidateOnly(options.validate_only)
+        }
+
+        if (options?.partial_failure) {
+            request.setPartialFailure(options.partial_failure)
+        }
+
+        const response = await this.serviceCall('uploadClickConversions', request, true)
+        return response
     }
 }

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -225,7 +225,7 @@ export default class Service {
         return `customers/${this.cid}/${resource}`
     }
 
-    protected async serviceCall(call: string, request: any): Promise<any> {
+    protected async serviceCall(call: string, request: any, all_results: boolean = false): Promise<any> {
         try {
             const response = await new Promise((resolve, reject) => {
                 this.service[call](request, (err: any, res: any) => {
@@ -241,7 +241,7 @@ export default class Service {
                 Since get returns an object, we always return the first item.
                 This should only ever be one item here, and it should exist.
             */
-            return parsed_results[0]
+            return all_results ? parsed_results : parsed_results[0]
         } catch (err) {
             throw new GrpcError(err, request)
         }
@@ -256,6 +256,12 @@ export default class Service {
     protected buildResource(resource: string, data: any): unknown {
         const pb = this.client.buildResource(resource, data)
         return pb
+    }
+
+    protected buildResources(resource: string, data: Array<any>): unknown {
+        return data.map(dat => {
+            return this.buildResource(resource, dat)
+        })
     }
 
     /* Base report method used in global customer instance */

--- a/src/tests/conversion_upload.test.ts
+++ b/src/tests/conversion_upload.test.ts
@@ -1,0 +1,40 @@
+import { newCustomer, CID } from '../test_utils'
+import { CallConversion, ClickConversion } from 'google-ads-node/build/lib/resources'
+
+const customer = newCustomer()
+
+describe('Conversion Upload Service', () => {
+    describe('reporting', () => {
+        it('can upload call conversions', async () => {
+            const call_conversions: CallConversion[] = [
+                {
+                    caller_id: `+442087599036`,
+                    call_start_date_time: `2020-04-01 12:32:45-08:00`,
+                    conversion_date_time: `2020-04-01 12:32:45-08:00`,
+                    conversion_action: `customers/${CID}/conversionActions/401955561`,
+                },
+            ]
+
+            const res = await customer.conversionUploads.uploadCallConversions(call_conversions, {
+                validate_only: true,
+                partial_failure: true,
+            })
+
+            expect(res.partial_failure_error)
+        })
+        it('can upload click conversions', async () => {
+            const click_conversions: ClickConversion[] = [
+                {
+                    gclid: CID,
+                },
+            ]
+
+            const res = await customer.conversionUploads.uploadClickConversions(click_conversions, {
+                validate_only: true,
+                partial_failure: true,
+            })
+
+            expect(res.partial_failure_error)
+        })
+    })
+})


### PR DESCRIPTION
**Conversion Upload Service**

- Unfortunately this is quite an annoying service to test as you actually need to attribute clicks and calls to the upload. We tried to fake it, and got as far as if we can get a response from Google we are assuming it will work correctly.

usage
```ts
const call_conversions: CallConversion[] = [
    {
        caller_id: `+442087599036`,
        call_start_date_time: `2020-04-01 12:32:45-08:00`,
        conversion_date_time: `2020-04-01 12:32:45-08:00`,
        conversion_action: `customers/${CID}/conversionActions/401955561`,
    },
]

const res = await customer.conversionUploads.uploadCallConversions(call_conversions)
```