### PR TITLE
feat(report): added support for specifying summary row setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     },
     "dependencies": {
         "bottleneck": "^2.16.1",
-        "google-ads-node": "1.15.3",
+        "google-ads-node": "1.15.4",
         "lodash": "^4.17.15",
         "redis": "^2.8.0",
         "request": "^2.88.0"

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -98,17 +98,19 @@ import {
     PreReportHook,
     MutateResourceOperation,
     ReportStreamOptions,
-    CreateCustomerOptions, CreateCustomerFlowSettings,
+    CreateCustomerOptions,
+    CreateCustomerFlowSettings,
+    QueryOptions,
 } from './types'
 
 export interface CustomerInstance {
     /* Base Customer properties for easy access */
-    readonly cid: string,
+    readonly cid: string
 
     /* Global customer methods */
     report: <T = any[]>(options: ReportOptions) => ReportResponse<T>
     reportStream: <T = any>(options: ReportStreamOptions) => AsyncGenerator<T>
-    query: (qry: string) => QueryResponse
+    query: (qry: string, options?: QueryOptions) => QueryResponse
     list: () => ListResponse
     get: (id: number | string) => GetResponse
     update: (customer: Customer, options?: ServiceCreateOptions) => UpdateResponse
@@ -116,7 +118,10 @@ export interface CustomerInstance {
         operations: Array<MutateResourceOperation>,
         options?: ServiceCreateOptions
     ) => MutateResourcesResponse
-    createCustomerClient: (options: CreateCustomerOptions, flow_settings?: CreateCustomerFlowSettings) => CreateCustomerResponse
+    createCustomerClient: (
+        options: CreateCustomerOptions,
+        flow_settings?: CreateCustomerFlowSettings
+    ) => CreateCustomerResponse
 
     /* Services */
     campaigns: CampaignService
@@ -203,7 +208,7 @@ export default function Customer(
         /* Top level customer methods */
         report: options => cusService.report(options),
         reportStream: options => cusService.reportStream(options),
-        query: qry => cusService.query(qry),
+        query: (qry, options) => cusService.query(qry, options),
         list: () => cusService.list(),
         get: id => cusService.get(id),
         update: (customer, options) => cusService.update(customer, options),

--- a/src/services/customer.ts
+++ b/src/services/customer.ts
@@ -1,11 +1,9 @@
 // manual_mode: This file has been manually modified and should not be touched by generate_services.js
 
 import * as grpc from 'google-ads-node'
-import {
-    Customer, CreateCustomerClientResponse
-} from 'google-ads-node/build/lib/resources'
+import { Customer, CreateCustomerClientResponse } from 'google-ads-node/build/lib/resources'
 import { getFieldMask } from 'google-ads-node/build/lib/utils'
-import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
+import { StringValue } from 'google-protobuf/google/protobuf/wrappers_pb'
 
 import GrpcClient from '../grpc'
 import Bottleneck from 'bottleneck'
@@ -18,9 +16,11 @@ import {
     PostReportHook,
     MutateResourceOperation,
     ReportStreamOptions,
-    CreateCustomerOptions, CreateCustomerFlowSettings,
+    CreateCustomerOptions,
+    CreateCustomerFlowSettings,
+    QueryOptions,
 } from '../types'
-import { CustomerInstance } from '../customer';
+import { CustomerInstance } from '../customer'
 
 export type ReportResponse<T> = Promise<T>
 export type QueryResponse = Promise<Array<any>>
@@ -51,8 +51,8 @@ export default class CustomerService extends Service {
         return this.serviceReportStream<T>(options)
     }
 
-    public async query(qry: string): QueryResponse {
-        const results = await this.serviceQuery(qry)
+    public async query(qry: string, options?: QueryOptions): QueryResponse {
+        const results = await this.serviceQuery(qry, options)
         return results
     }
 
@@ -197,7 +197,7 @@ export default class CustomerService extends Service {
             throw new TypeError(`Missing 'gads_api' in 'flow_settings'.`)
         }
 
-        const request = new grpc.CreateCustomerClientRequest();
+        const request = new grpc.CreateCustomerClientRequest()
 
         const customerClientPB = this.buildResource('Customer', options.customer_client) as grpc.Customer
 
@@ -216,10 +216,7 @@ export default class CustomerService extends Service {
             request.setEmailAddress(emailValue)
         }
 
-        const response = await this.serviceCall(
-                'createCustomerClient',
-                request,
-            ) as CreateCustomerClientResponse
+        const response = (await this.serviceCall('createCustomerClient', request)) as CreateCustomerClientResponse
 
         if (!flow_settings || !flow_settings.return_customer) {
             return response
@@ -230,7 +227,7 @@ export default class CustomerService extends Service {
         return flow_settings.gads_api.Customer({
             customer_account_id: customer_id,
             refresh_token: this.client.getRefreshToken(),
-            login_customer_id: options.customer_id
-        });
+            login_customer_id: options.customer_id,
+        })
     }
 }

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -7,7 +7,7 @@ import { SummaryRowSetting } from 'google-ads-node/build/lib/enums'
 
 import GrpcClient from '../grpc'
 import { formatQueryResults, buildReportQuery, parseResult, parsePartialFailureErrors } from '../utils'
-import { ServiceListOptions, ServiceCreateOptions, ReportStreamOptions } from '../types'
+import { ServiceListOptions, ServiceCreateOptions, ReportStreamOptions, QueryOptions } from '../types'
 import { GrpcError } from '../error'
 import { ReportOptions, PreReportHook, PostReportHook } from '../types'
 
@@ -362,8 +362,8 @@ export default class Service {
     }
 
     /* Base query method used in global customer instance */
-    protected async serviceQuery(qry: string): Promise<any> {
-        const results = await this.getSearchData(qry)
+    protected async serviceQuery(qry: string, options?: QueryOptions): Promise<any> {
+        const results = await this.getSearchData(qry, 10000, options?.summary_row)
         return this.parseServiceResults(results)
     }
 

--- a/src/tests/error.test.ts
+++ b/src/tests/error.test.ts
@@ -47,7 +47,7 @@ describe('Error', () => {
                 pageSize: 10000,
                 validateOnly: false,
                 returnTotalResultsCount: false,
-                summaryRowSetting: 0,
+                summaryRowSetting: enums.SummaryRowSetting.NO_SUMMARY_ROW,
             })
             expect(typeof err.request_id).toBe('string')
         }

--- a/src/tests/report.test.ts
+++ b/src/tests/report.test.ts
@@ -237,6 +237,26 @@ describe('Reporting', () => {
         expect(only_summary_row.length).toEqual(1)
         expect(results_with_summary_row[results_with_summary_row.length - 1]).toEqual(only_summary_row[0])
     })
+
+    it('supports the query method', async () => {
+        const [results] = await customer.query(`SELECT campaign.id, metrics.cost_micros FROM campaign`)
+        expect(results).toEqual({
+            campaign: {
+                resource_name: expect.any(String),
+                id: expect.any(Number),
+            },
+            metrics: {
+                cost_micros: expect.any(Number),
+            },
+        })
+    })
+
+    it('supports specifying the summary row setting with query', async () => {
+        const summary_results = await customer.query(`SELECT metrics.clicks FROM campaign`, {
+            summary_row: SummaryRowSetting.SUMMARY_ROW_ONLY,
+        })
+        expect(summary_results.length).toEqual(1)
+    })
 })
 
 describe('Reporting (zero metric rows)', () => {

--- a/src/tests/report.test.ts
+++ b/src/tests/report.test.ts
@@ -1,7 +1,6 @@
 import { orderBy } from 'lodash'
 import { newCustomerWithMetrics, newCustomer } from '../test_utils'
-
-import { AdGroupStatus, AdType } from 'google-ads-node/build/lib/enums'
+import { AdGroupStatus, AdType, SummaryRowSetting } from 'google-ads-node/build/lib/enums'
 
 describe('Reporting', () => {
     const customer = newCustomerWithMetrics()
@@ -213,6 +212,30 @@ describe('Reporting', () => {
             constraints: [{ 'campaign.id': '0123456789' }],
         })
         expect(row.length).toEqual(0)
+    })
+
+    it('supports using the summary row setting', async () => {
+        const [no_summary_row_results, results_with_summary_row, only_summary_row] = await Promise.all([
+            customer.report({
+                entity: 'campaign',
+                metrics: ['metrics.cost_micros', 'metrics.clicks', 'metrics.impressions'],
+                limit: 1,
+            }),
+            customer.report({
+                entity: 'campaign',
+                metrics: ['metrics.cost_micros', 'metrics.clicks', 'metrics.impressions'],
+                summary_row: SummaryRowSetting.SUMMARY_ROW_WITH_RESULTS,
+            }),
+            customer.report({
+                entity: 'campaign',
+                metrics: ['metrics.cost_micros', 'metrics.clicks', 'metrics.impressions'],
+                summary_row: SummaryRowSetting.SUMMARY_ROW_ONLY,
+            }),
+        ])
+
+        expect(no_summary_row_results.length).toEqual(1)
+        expect(only_summary_row.length).toEqual(1)
+        expect(results_with_summary_row[results_with_summary_row.length - 1]).toEqual(only_summary_row[0])
     })
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import * as fields from 'google-ads-node/build/lib/fields'
-import { CreateCustomerClientRequest, Customer } from 'google-ads-node/build/lib/resources';
-import { GoogleAdsNodeOptions } from './grpc';
-import GoogleAdsApi from './client';
+import { CreateCustomerClientRequest, Customer } from 'google-ads-node/build/lib/resources'
+import { SummaryRowSetting } from 'google-ads-node/build/lib/enums'
+import { GoogleAdsNodeOptions } from './grpc'
+import GoogleAdsApi from './client'
 
 export type Attributes =
     | fields.AccountBudgetFields
@@ -172,6 +173,7 @@ export interface BaseReportOptions {
     limit?: number
     order_by?: string | Array<string>
     sort_order?: string
+    summary_row?: SummaryRowSetting
 }
 
 export interface ReportOptions extends BaseReportOptions {
@@ -312,5 +314,5 @@ interface CreateCustomerFlowSettingsWithCustomer {
 }
 
 export type CreateCustomerFlowSettings =
-  | CreateCustomerFlowSettingsWithoutCustomer
-  | CreateCustomerFlowSettingsWithCustomer
+    | CreateCustomerFlowSettingsWithoutCustomer
+    | CreateCustomerFlowSettingsWithCustomer

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,10 @@ export interface BaseReportOptions {
     summary_row?: SummaryRowSetting
 }
 
+export interface QueryOptions {
+    summary_row?: SummaryRowSetting
+}
+
 export interface ReportOptions extends BaseReportOptions {
     page_size?: number
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,9 +459,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.153"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.153.tgz#5cb7dded0649f1df97938ac5ffc4f134e9e9df98"
-  integrity sha512-lYniGRiRfZf2gGAR9cfRC3Pi5+Q1ziJCKqPmjZocigrSJUVPWf7st1BtSJ8JOeK0FLXVndQ1IjUjTco9CXGo/Q==
+  version "4.14.155"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
+  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
 
 "@types/lodash@^4.14.112":
   version "4.14.138"
@@ -479,9 +479,9 @@
   integrity sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==
 
 "@types/node@^13.7.0":
-  version "13.13.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.9.tgz#79df4ae965fb76d31943b54a6419599307a21394"
-  integrity sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==
+  version "13.13.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.10.tgz#34a9be3cbc409fd235984bd18a130006f5234396"
+  integrity sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q==
 
 "@types/protobufjs@^6.0.0":
   version "6.0.0"
@@ -2027,10 +2027,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-google-ads-node@1.15.3:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.15.3.tgz#2475eeca061af92a4113862fd0fb06da8a0fc3f4"
-  integrity sha512-4vFPA9gcbUBpv/8/0BsZyJSWYgAxcJ0YFhRr5N/f+g2G/VVNs8dMECBhN3dMBQgscs2ImGZYSev1OMWkPl1hNQ==
+google-ads-node@^1.15.4:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.15.4.tgz#234fc02bb1ddc0d191605ab3e5fb423529a18245"
+  integrity sha512-zV3e4A4yZhwifNCDMn+hhMPJHKXEaAvZGUWCiior4MNtuYVYSVt4HHYaV+hPK+4lsSY4XjLDFGq3Kmpwun4maQ==
   dependencies:
     "@types/cosmiconfig" "^5.0.3"
     "@types/google-protobuf" "^3.2.7"
@@ -2088,15 +2088,15 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 grpc@^1.21.1:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.2.tgz#76d047bfa7b05b607cbbe3abb99065dcefe0c099"
-  integrity sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==
+  version "1.24.3"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.3.tgz#92efe28dfc1250dca179b8133e40b4f2341473d9"
+  integrity sha512-EDemzuZTfhM0hgrXqC4PtR76O3t+hTIYJYR5vgiW0yt2WJqo4mhxUqZUirzUQz34Psz7dbLp38C6Cl7Ij2vXRQ==
   dependencies:
     "@types/bytebuffer" "^5.0.40"
     lodash.camelcase "^4.3.0"
     lodash.clone "^4.5.0"
     nan "^2.13.2"
-    node-pre-gyp "^0.14.0"
+    node-pre-gyp "^0.15.0"
     protobufjs "^5.0.3"
 
 gtoken@^2.3.2:
@@ -3488,7 +3488,7 @@ mkdirp@0.x:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -3542,7 +3542,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
+needle@^2.2.1, needle@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.0.tgz#e6fc4b3cc6c25caed7554bd613a5cf0bac8c31c0"
   integrity sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==
@@ -3608,14 +3608,14 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pre-gyp@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
+node-pre-gyp@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz#c2fc383276b74c7ffa842925241553e8b40f1087"
+  integrity sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==
   dependencies:
     detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
+    mkdirp "^0.5.3"
+    needle "^2.5.0"
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature update to the `report` and `query` method

*   **What is the current behavior?** (You can also link to an open issue here)
Currently you can't specify the summary row setting

-   **What is the new behavior (if this is a feature change)?**
You can now specifiy `summary_row` in the `report` method, using `enums.SummaryRowSetting`. By default, it's set to `NO_SUMMARY_ROW`.

**Report Example**:
```ts
// Summary row with results (added to the end of the results array)
customer.report({
  entity: 'campaign',
  metrics: ['metrics.cost_micros', 'metrics.clicks', 'metrics.impressions'],
  summary_row: enums.SummaryRowSetting.SUMMARY_ROW_WITH_RESULTS,
})

// Summary row only (only item in the results array)
customer.report({
  entity: 'campaign',
  metrics: ['metrics.cost_micros', 'metrics.clicks', 'metrics.impressions'],
  summary_row: enums.SummaryRowSetting.SUMMARY_ROW_ONLY,
})
```

**Query Example**:
```ts
const results = await customer.query(`SELECT metrics.clicks FROM campaign`, {
  summary_row: SummaryRowSetting.SUMMARY_ROW_ONLY,
})
```

*   **Other information**:
~Requires this PR into google-ads-node to be merged first: https://github.com/Opteo/google-ads-node/pull/44~ google-ads-node has been upgraded to 1.15.4 in this PR
