### PR TITLE
feat(total-results-count): Concept of returning totalResultsCount value for SearchAdsRequest

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -145,7 +145,8 @@ export default class GrpcClient {
         query: string,
         page_size?: number,
         page_token?: string,
-        summary_row?: SummaryRowSetting
+        summary_row?: SummaryRowSetting,
+        return_total_results_count?: boolean
     ): BuildSearchRequestResponse {
         const request = new SearchGoogleAdsRequest()
         request.setCustomerId(customer_id)
@@ -159,6 +160,9 @@ export default class GrpcClient {
         }
         if (summary_row) {
             request.setSummaryRowSetting(summary_row)
+        }
+        if (return_total_results_count) {
+            request.setReturnTotalResultsCount(return_total_results_count)
         }
 
         const has_limit = query.toLowerCase().includes(' limit ')

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,10 +174,12 @@ export interface BaseReportOptions {
     order_by?: string | Array<string>
     sort_order?: string
     summary_row?: SummaryRowSetting
+    return_total_results_count?: boolean
 }
 
 export interface QueryOptions {
     summary_row?: SummaryRowSetting
+    return_total_results_count?: boolean
 }
 
 export interface ReportOptions extends BaseReportOptions {
@@ -320,3 +322,12 @@ interface CreateCustomerFlowSettingsWithCustomer {
 export type CreateCustomerFlowSettings =
     | CreateCustomerFlowSettingsWithoutCustomer
     | CreateCustomerFlowSettingsWithCustomer
+
+export type TotalResultsIterableData = {
+    totalResultsCount: number
+    resultsList: Array<object>
+}
+export type TotalResultsIterable = {
+    [Symbol.iterator](): Generator
+    totalResultsCount: number
+}


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature(semi)

*   **What is the current behavior?** (You can also link to an open issue here)
doesn't exists

-   **What is the new behavior (if this is a feature change)?**
```js
      const report = await customer.customer_client.report({
          entity: "campaign",
          attributes: ["campaign.id"],
          constraints: [
            {
              key: "campaign.status",
              op: "IN",
              val: [enums.CampaignStatus.ENABLED, enums.CampaignStatus.PAUSED]
            }
          ],
          limit: 1,
          return_total_results_count: true
        });
```
Set `limit` to 1 because it anyway will be ignored in data processing flow and API will return you, before after request flow start, less data - so it will be faster to run this request.
Do not set `page_size` - `return_total_results_count` doesn't work with it.
Do not set `return_total_results_count` - it's useless with `return_total_results_count` because result will be ignored but API backend will do additional processings.
Result will be be next: `[number]`, where `number` is `total_results_count` from https://developers.google.com/google-ads/api/reference/rpc/v3/SearchGoogleAdsResponse

*   **Other information**:
We have this function https://github.com/Opteo/google-ads-api/blob/b91dd12c55f8afc4e3663332a3a4eec37dc41fce/src/utils.ts#L279
It's executed for every response result.
It executes `convertFakeArrays` which basically takes keys from given object and converts values under a key to an element in array (i'm very simplifying it here).
Idea behind my change is to introduce as little as possible changes, as you can see I used Symbol.Iterator to mock Array type returned by getSearchData here https://github.com/Opteo/google-ads-api/blob/b91dd12c55f8afc4e3663332a3a4eec37dc41fce/src/services/service.ts#L410
Doing this allowed me to transmit `totalResultsCount` property down to `convertFakeArrays`.

Of course it looks a bit hacky 😆 But it covers statistics collection functionality when you have millions of ads, keywords under customer, and you need to know exact amount of ads customer has, and using `.report` or event `.reportStream` basically not rely good solution.

This PR is a concept to start. discussion on how to improve or change it.

Additional example. If you execute this request(no matter `report` or `reportStream`:
```js
        const report = await customer.customer_client.report({
          entity: "keyword_view",
          attributes: ["ad_group.id"],
          constraints: [
            {
              key: "ad_group.status",
              op: "!=",
              val: enums.AdGroupStatus.REMOVED
            },
            {
              key: "campaign.status",
              op: "!=",
              val: enums.CampaignStatus.REMOVED
            },
            {
              key: "ad_group_criterion.status",
              op: "!=",
              val: enums.AdGroupCriterionStatus.REMOVED
            }
          ]
        });
```
You don't have possibility to quickly know how many keywords Customer has before you either receive total response(10k max per page and if millions of items it takes time) or count items received from stream. Both variants are slow and I saw that grcp connection can also through internal errors and drop connection (node 14+).

So for 3 customers I used for testing it took 47 minutes. We have much more customers which have keywords amount almost at customer limit (5mln).

But if you. execute this code:
```js
        const report = await customer.customer_client.report({
          entity: "keyword_view",
          attributes: ["ad_group.id"],
          constraints: [
            {
              key: "ad_group.status",
              op: "!=",
              val: enums.AdGroupStatus.REMOVED
            },
            {
              key: "campaign.status",
              op: "!=",
              val: enums.CampaignStatus.REMOVED
            },
            {
              key: "ad_group_criterion.status",
              op: "!=",
              val: enums.AdGroupCriterionStatus.REMOVED
            }
          ],
          limit: 1,
          return_total_results_count: true
        });

       console.log('report:', customer.id, report);
```

For 3 example customers I got next response:
```bash
report: 4721311082 [ 133781 ]
report: 1608191749 [ 1632956 ]
report: 3826494945 [ 4849232 ]
```
It took 3108ms, so a bit more than 3 seconds. You can see that first customer has only 133k keywords, second customer has 1.6ml, and third one has almost 5mln.
