### PR TITLE
Add summaryRow after all normal results

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -116,11 +116,6 @@ export default class GrpcClient {
         let response = await this.searchWithRetry(throttler, request)
         results = results.concat(response.resultsList)
 
-        const summary_row = request.getSummaryRowSetting()
-        if ([SummaryRowSetting.SUMMARY_ROW_ONLY, SummaryRowSetting.SUMMARY_ROW_WITH_RESULTS].includes(summary_row)) {
-            results = results.concat([response.summaryRow])
-        }
-
         const hasNextPage = (res: any) => res && res.nextPageToken
 
         while (hasNextPage(response)) {
@@ -135,6 +130,11 @@ export default class GrpcClient {
                 results = results.slice(0, limit)
                 break
             }
+        }
+
+        const summary_row = request.getSummaryRowSetting()
+        if ([SummaryRowSetting.SUMMARY_ROW_ONLY, SummaryRowSetting.SUMMARY_ROW_WITH_RESULTS].includes(summary_row)) {
+            results = results.concat([response.summaryRow])
         }
 
         return results

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,7 +2027,7 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-google-ads-node@^1.15.4:
+google-ads-node@1.15.4:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.15.4.tgz#234fc02bb1ddc0d191605ab3e5fb423529a18245"
   integrity sha512-zV3e4A4yZhwifNCDMn+hhMPJHKXEaAvZGUWCiior4MNtuYVYSVt4HHYaV+hPK+4lsSY4XjLDFGq3Kmpwun4maQ==


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

*   **What is the current behavior?**
In reports with the number of rows > page_size and SummaryRowSetting = SUMMARY_ROW_WITH_RESULTS, the summary row is inserted after the first page, but it is only available in the last page.

-   **What is the new behavior (if this is a feature change)?**
summaryRow is added after all normal rows

*   **Other information**:
