### PR TITLE
chore(deps): upgraded google-ads-node to 1.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     },
     "dependencies": {
         "bottleneck": "^2.16.1",
-        "google-ads-node": "1.15.4",
+        "google-ads-node": "1.15.5",
         "lodash": "^4.17.15",
         "redis": "^2.8.0",
         "request": "^2.88.0"

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -210,7 +210,7 @@ export default class Service {
                 partial_failure_error: parsed_results.partial_failure_error,
                 results: parsed_results.mutate_operation_responses.map((r: any) => {
                     // @ts-ignore Object.values not recognised
-                    const { resource_name } = Object.values(r)[0]
+                    const { resource_name } = Object.values(r).filter(r => r)[0]
                     return resource_name
                 }),
             }

--- a/src/tests/customer.test.ts
+++ b/src/tests/customer.test.ts
@@ -11,7 +11,8 @@ import {
     getRandomName,
     CAMPAIGN_ID,
     newCustomerWithNodeOptions,
-    newMccCustomer, newGadsAPIClient,
+    newMccCustomer,
+    newGadsAPIClient,
 } from '../test_utils'
 import { CreateCustomerFlowSettings, CreateCustomerOptions, MutateResourceOperation } from '../types'
 
@@ -273,7 +274,7 @@ describe('customer', () => {
                     descriptive_name: getRandomName('account'),
                     currency_code: 'CAD',
                     time_zone: 'America/Toronto',
-                }
+                },
             }
             const result = await master_customer.createCustomerClient(c)
 
@@ -281,7 +282,7 @@ describe('customer', () => {
             expect(result).toBeDefined()
             expect(typeof result).toBe('object')
             expect((result as CreateCustomerClientResponse).resource_name).toBeDefined()
-            expect((result as CreateCustomerClientResponse).resource_name!.includes('customers/')).toEqual(true);
+            expect((result as CreateCustomerClientResponse).resource_name!.includes('customers/')).toEqual(true)
         })
 
         it('should create a new sub customer and return CustomerInstance', async () => {
@@ -291,11 +292,11 @@ describe('customer', () => {
                     descriptive_name: getRandomName('account'),
                     currency_code: 'CAD',
                     time_zone: 'America/Toronto',
-                }
+                },
             }
             const flow_settings: CreateCustomerFlowSettings = {
                 return_customer: true,
-                gads_api: client
+                gads_api: client,
             }
 
             const result = await master_customer.createCustomerClient(c, flow_settings)

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,9 +459,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.155"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
-  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
+  version "4.14.156"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.156.tgz#cbe30909c89a1feeb7c60803e785344ea0ec82d1"
+  integrity sha512-l2AgHXcKUwx2DsvP19wtRPqZ4NkONjmorOdq4sMcxIjqdIuuV/ULo2ftuv4NUpevwfW7Ju/UKLqo0ZXuEt/8lQ==
 
 "@types/lodash@^4.14.112":
   version "4.14.138"
@@ -479,9 +479,9 @@
   integrity sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==
 
 "@types/node@^13.7.0":
-  version "13.13.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.10.tgz#34a9be3cbc409fd235984bd18a130006f5234396"
-  integrity sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q==
+  version "13.13.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.12.tgz#9c72e865380a7dc99999ea0ef20fc9635b503d20"
+  integrity sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==
 
 "@types/protobufjs@^6.0.0":
   version "6.0.0"
@@ -805,10 +805,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bignumber.js@^7.0.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
-  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 bluebird@^3.5.2:
   version "3.5.5"
@@ -1748,9 +1748,9 @@ fast-levenshtein@~2.0.4:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fast-text-encoding@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.2.tgz#ff1ad5677bde049e0f8656aa6083a7ef2c5836e2"
-  integrity sha512-5rQdinSsycpzvAoHga2EDn+LRX1d5xLFsuNG0Kg61JrAT/tASXcLL0nf/33v+sAxlQcfYmWbTURa1mmAf55jGw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
+  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -2032,10 +2032,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-google-ads-node@1.15.4:
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.15.4.tgz#234fc02bb1ddc0d191605ab3e5fb423529a18245"
-  integrity sha512-zV3e4A4yZhwifNCDMn+hhMPJHKXEaAvZGUWCiior4MNtuYVYSVt4HHYaV+hPK+4lsSY4XjLDFGq3Kmpwun4maQ==
+google-ads-node@1.15.5:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-1.15.5.tgz#b9b594c2b731ef84e2b268ebd3efbc610f2f00f2"
+  integrity sha512-D9pvxppwhpJR9NxgNKGWhnNj0JJTfBJ7gcTP8BGGMpvyCxyigtYnYLUpUgkIIPnjI+E7d2ZW6G4V2KTwySxOTw==
   dependencies:
     "@types/cosmiconfig" "^5.0.3"
     "@types/google-protobuf" "^3.2.7"
@@ -2978,11 +2978,11 @@ jsesc@^2.5.1:
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
 json-bigint@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.3.0.tgz#0ccd912c4b8270d05f056fbd13814b53d3825b1e"
-  integrity sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.3.1.tgz#0c1729d679f580d550899d6a2226c228564afe60"
+  integrity sha512-DGWnSzmusIreWlEupsUelHrhwmPPE+FiQvg+drKfk2p+bdEYa5mp4PJ8JsCWqae0M2jQNb0HPvnwvf1qOTThzQ==
   dependencies:
-    bignumber.js "^7.0.0"
+    bignumber.js "^9.0.0"
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Upgraded google-ads-node to 1.15.5

*   **What is the current behavior?** (You can also link to an open issue here)
google-ads-node is at version 1.15.4

-   **What is the new behavior (if this is a feature change)?**
Upgraded google-ads-node to 1.15.5, plus a minor fix for partial failure error formatting and some linting.

*   **Other information**:
This should speed up most queries (particularly for large datasets), see the gads node PR for more details: https://github.com/Opteo/google-ads-node/pull/45