### PR TITLE
fix: applying correct service names within google ads node

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     },
     "dependencies": {
         "bottleneck": "^2.16.1",
-        "google-ads-node": "2.0.1",
+        "google-ads-node": "2.0.2",
         "lodash": "^4.17.15",
         "redis": "^2.8.0",
         "request": "^2.88.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,10 +2032,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-google-ads-node@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-2.0.1.tgz#08d93eb04b740a509d120e4e82c114c99606ea66"
-  integrity sha512-kvTV07nSCABi0E7/38fGg7xsXbz9VOg0WGE7Zw08z+pCuN9fXWqLysRU0TYUejXWa/9Z+1C+qMcWYjryHv3Azw==
+google-ads-node@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-2.0.2.tgz#be92837676f073a8482b0ec279dcf031cf1fa0a6"
+  integrity sha512-1t3f/64guiHLQJNpq4W18Cqu+UmngKq4yidSXfQBx0PtFYFtRVA4MUz8vDnN3/2072pt9Gp+X7tTAOdo/mv0og==
   dependencies:
     "@types/cosmiconfig" "^5.0.3"
     "@types/google-protobuf" "^3.2.7"


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixing an issue where the ThirdPartyAnalyticsAppLinkService was not being found within google-ads-node

*   **What is the current behavior?** (You can also link to an open issue here)
This service doesn't exist when asked for

-   **What is the new behavior (if this is a feature change)?**
The service now exists

*   **Other information**:
