### PR TITLE
fix(errors): expose policy violation details when received

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,10 @@
 import { get } from 'lodash'
-import { SearchGoogleAdsRequest, MutateGoogleAdsRequest } from 'google-ads-node'
+import {
+    SearchGoogleAdsRequest,
+    MutateGoogleAdsRequest,
+    PolicyTopicEntry,
+    PolicyViolationDetails,
+} from 'google-ads-node'
 
 export class GrpcError extends Error {
     public readonly code: number
@@ -7,6 +12,7 @@ export class GrpcError extends Error {
     public readonly request_id: string
     public readonly location: string
     public readonly failure: any
+    public readonly policy_violation_details: PolicyTopicEntry.AsObject[] | PolicyViolationDetails.AsObject | undefined
 
     constructor(err: any, request: SearchGoogleAdsRequest | MutateGoogleAdsRequest) {
         const { code, details } = err
@@ -26,6 +32,16 @@ export class GrpcError extends Error {
         this.request = request.toObject()
         this.request_id = get(err, "metadata._internal_repr['request-id'][0]")
         this.location = get(err, "metadata._internal_repr['location'][0]")
+        this.policy_violation_details = get(err, "metadata._internal_repr['policy-violation-details-bin'][0]")
         this.failure = err
+
+        // Decode policy violation details buffer if it exists
+        if (this.policy_violation_details) {
+            try {
+                this.policy_violation_details = JSON.parse(this.policy_violation_details.toString())
+            } catch {
+                this.policy_violation_details = undefined
+            }
+        }
     }
 }

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -25,6 +25,12 @@ export interface GoogleAdsNodeOptions {
     logging?: LogOptions
 }
 
+interface SearchResponse {
+    resultsList: any[]
+    nextPageToken: string
+    summaryRow: any
+}
+
 export default class GrpcClient {
     private readonly client: GoogleAdsClient
 
@@ -115,7 +121,7 @@ export default class GrpcClient {
 
         let results: Array<object> = []
 
-        let response = await this.searchWithRetry(throttler, request)
+        let response = (await this.searchWithRetry(throttler, request)) as SearchResponse
         results = results.concat(response.resultsList)
 
         const hasNextPage = (res: any) => res && res.nextPageToken
@@ -124,7 +130,7 @@ export default class GrpcClient {
             const next_page_request = request.clone() as SearchGoogleAdsRequest
             next_page_request.setPageToken(response.nextPageToken)
 
-            response = await this.searchWithRetry(throttler, next_page_request)
+            response = (await this.searchWithRetry(throttler, next_page_request)) as SearchResponse
             results = results.concat(response.resultsList)
 
             // If there is no limit, `limit` will be set to 0.

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -381,7 +381,9 @@ export default class Service {
         try {
             if (limit && page_size && page_size >= limit) {
                 const response = await this.client.searchWithRetry(this.throttler, request)
+                // @ts-ignore This is fine
                 if (response && response.hasOwnProperty('resultsList')) {
+                    // @ts-ignore This is fine
                     return response.resultsList
                 }
                 return []

--- a/src/tests/policy_violation.test.ts
+++ b/src/tests/policy_violation.test.ts
@@ -1,0 +1,104 @@
+import { AdGroupAdStatus, AdGroupCriterionStatus, KeywordMatchType } from 'google-ads-node/build/lib/enums'
+import { AdGroupCriterion, AdGroupAd } from 'google-ads-node/build/lib/resources'
+
+import { newCustomer, CID, ADGROUP_ID } from '../test_utils'
+const customer = newCustomer()
+
+describe('Policy Violation Details', () => {
+    it('throws an error with policy violation details when adding an illegal keyword', async () => {
+        const keyword: AdGroupCriterion = {
+            ad_group: `customers/${CID}/adGroups/${ADGROUP_ID}`,
+            status: AdGroupCriterionStatus.PAUSED,
+            keyword: {
+                text: 'medication',
+                match_type: KeywordMatchType.EXACT,
+            },
+        }
+
+        try {
+            await customer.adGroupCriteria.create(keyword, { validate_only: true })
+        } catch (err) {
+            expect(err.policy_violation_details).toBeDefined()
+            expect(err.policy_violation_details.externalPolicyDescription).toContain('pharmacy-related content')
+            expect(err.policy_violation_details.key).toEqual({
+                policyName: {
+                    value: 'pharma',
+                },
+                violatingText: {
+                    value: 'medication',
+                },
+            })
+        }
+    })
+
+    it('throws an error with policy finding details when using an illegal character in an ad', async () => {
+        const ad: AdGroupAd = {
+            ad_group: `customers/${CID}/adGroups/${ADGROUP_ID}`,
+            status: AdGroupAdStatus.PAUSED,
+            ad: {
+                final_urls: ['https://example.com'],
+                expanded_text_ad: {
+                    headline_part1: "I'm an illegal character 😎",
+                    headline_part2: 'headline part 2',
+                    headline_part3: 'headline part 3',
+                    path1: 'path1',
+                    path2: 'path2',
+                    description: 'description',
+                },
+            },
+        }
+
+        try {
+            await customer.adGroupAds.create(ad, { validate_only: true })
+        } catch (err) {
+            expect(err.policy_violation_details).toEqual([
+                {
+                    topic: { value: 'SYMBOLS' },
+                    type: 2,
+                    evidencesList: [{ textList: { textsList: [{ value: '😎' }] } }],
+                    constraintsList: [],
+                },
+            ])
+        }
+    })
+
+    it('throws an error with policy violation details when using global mutateResources', async () => {
+        const ad: AdGroupAd = {
+            ad_group: `customers/${CID}/adGroups/${ADGROUP_ID}`,
+            status: AdGroupAdStatus.PAUSED,
+            ad: {
+                final_urls: ['https://example.com'],
+                expanded_text_ad: {
+                    headline_part1: "I'm an illegal character 😎",
+                    headline_part2: 'headline part 2',
+                    headline_part3: 'headline part 3',
+                    path1: 'path1',
+                    path2: 'path2',
+                    description: 'description',
+                },
+            },
+        }
+
+        try {
+            await customer.mutateResources(
+                [
+                    {
+                        _resource: 'AdGroupAd',
+                        _operation: 'create',
+                        ...ad,
+                    },
+                ],
+                { validate_only: true }
+            )
+        } catch (err) {
+            expect(err.policy_violation_details).toEqual([
+                {
+                    topic: { value: 'SYMBOLS' },
+                    type: 2,
+                    evidencesList: [{ textList: { textsList: [{ value: '😎' }] } }],
+                    constraintsList: [],
+                },
+            ])
+        }
+    })
+})


### PR DESCRIPTION
Upstream support for this fix https://github.com/Opteo/google-ads-node/pull/60. I've also fixed some minor type issues and added tests for policy violations