### PR TITLE
Access token v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can improve the documentation by sending pull requests with edits to [these 
 ```javascript
 import { GoogleAdsApi, types, enums } from 'google-ads-api'
 
+// FIXME documentare service account
 // 1. Create a new client with your credentials
 const client = new GoogleAdsApi({
     client_id: '<CLIENT_ID>',

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ You can improve the documentation by sending pull requests with edits to [these 
 ```javascript
 import { GoogleAdsApi, types, enums } from 'google-ads-api'
 
-// FIXME documentare service account
 // 1. Create a new client with your credentials
 const client = new GoogleAdsApi({
     client_id: '<CLIENT_ID>',

--- a/package.json
+++ b/package.json
@@ -73,8 +73,10 @@
         "typescript": "^3.7.2"
     },
     "dependencies": {
+        "@types/jsrsasign": "^8.0.2",
         "bottleneck": "^2.16.1",
         "google-ads-node": "2.0.4",
+        "jsrsasign": "^8.0.15",
         "lodash": "^4.17.15",
         "redis": "^2.8.0",
         "request": "^2.88.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,8 @@ interface ListAccessibleCustomersOptions extends GoogleAdsNodeOptions {
 
 export default class GoogleAdsApi {
     private readonly options: ClientOptions
-    private access_token: string = '';
+    private access_token: string = ''
+    private token_expiration: number = 0
     private throttler: Bottleneck
 
     constructor(options: ClientOptions) {
@@ -115,6 +116,15 @@ export default class GoogleAdsApi {
     public async requestAndSetAccessToken(service_account: ServiceAccount, sub: string) {
         let token_object = await getAccessTokenByServiceAccount(service_account, sub);
         this.access_token = token_object.access_token;
+        this.token_expiration = token_object.expires_in;
+    }
+
+    public IsTokenExpired() : boolean {
+        return this.token_expiration < Date.now()
+    }
+
+    public getTokenExpiration() : number {
+        return this.token_expiration
     }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -112,8 +112,8 @@ export default class GoogleAdsApi {
         return resource_names
     }
 
-    public async requestAndSetAccessToken(service_account: ServiceAccount) {
-        let token_object = await getAccessTokenByServiceAccount(service_account);
+    public async requestAndSetAccessToken(service_account: ServiceAccount, sub: string) {
+        let token_object = await getAccessTokenByServiceAccount(service_account, sub);
         this.access_token = token_object.access_token;
     }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -105,6 +105,7 @@ export default class GoogleAdsApi {
             refresh_token as string,
             '', // login-customer-id not needed for this function
             '', // linked-customer-id not needed for this function
+            this.access_token,
             gads_node_options
         )
 

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -41,6 +41,7 @@ export default class GrpcClient {
         readonly refresh_token: string,
         login_customer_id: string,
         linked_customer_id: string,
+        access_token: string,
         gads_node_options: GoogleAdsNodeOptions
     ) {
         const additional_options: any = {}
@@ -60,6 +61,7 @@ export default class GrpcClient {
             refresh_token,
             login_customer_id,
             linked_customer_id,
+            access_token,
             parseResults: true,
             async accessTokenGetter(clientId: string, clientSecret: string, refreshToken: string) {
                 return getAccessToken({

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -84,11 +84,12 @@ export async function getCustomerAccessToken() {
         private_key: data.private_key,
         auth_uri: data.auth_uri,
         token_uri: data.token_uri,
-        client_email: data.client_email,
-        sub: data.sub
+        client_email: data.client_email
     };
 
+    const sub = process.env.GOOGLE_ADS_SUB as string;
+
     const client = new GoogleAdsApi(options)
-    await client.requestAndSetAccessToken(service_account)
+    await client.requestAndSetAccessToken(service_account, sub);
     return client.Customer({"customer_account_id": process.env.GOOGLE_ADS_CUSTOMER_ID})
 }

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -69,3 +69,26 @@ export function newCustomerWithNodeOptions(options: GoogleAdsNodeOptions) {
 export function getRandomName(entity: string) {
     return `test-${entity}-${(Math.random() * 100000 + 1).toFixed(0)}`
 }
+
+
+export async function getCustomerAccessToken() {
+
+    const data =  JSON.parse(process.env.GOOGLE_ADS_SERVICE_ACCOUNT as string);
+    const options = {
+        developer_token: process.env.GOOGLE_ADS_DEVELOPER_TOKEN as string,
+        client_id: data.client_id,
+        client_secret: ''
+    }
+
+    const service_account = {
+        private_key: data.private_key,
+        auth_uri: data.auth_uri,
+        token_uri: data.token_uri,
+        client_email: data.client_email,
+        sub: data.sub
+    };
+
+    const client = new GoogleAdsApi(options)
+    await client.requestAndSetAccessToken(service_account)
+    return client.Customer({"customer_account_id": process.env.GOOGLE_ADS_CUSTOMER_ID})
+}

--- a/src/tests/access_token.test.ts
+++ b/src/tests/access_token.test.ts
@@ -1,0 +1,13 @@
+import { getCustomerAccessToken} from '../test_utils'
+
+describe('AccessTokenTest', () => {
+
+    it('can retrieve a list of Campaigns with all fields (if valid)', async() => {
+        const customer = await getCustomerAccessToken()
+        const list = await customer.conversionActions.list();
+        expect(list)
+    })
+})
+
+
+

--- a/src/tests/access_token.test.ts
+++ b/src/tests/access_token.test.ts
@@ -8,6 +8,3 @@ describe('AccessTokenTest', () => {
         expect(list)
     })
 })
-
-
-

--- a/src/token.ts
+++ b/src/token.ts
@@ -16,6 +16,13 @@ interface TokenReturn {
     expires_in: number
 }
 
+// FIXME getAccessTokenForServiceAccount = async (ServiceAccount definito in client.ts) => {
+//    ...... nostra impl
+//    ... deve ritornare una promise dove nel then risolve con il body della CURL JSON parsato
+//    .. attenzione a gestione cache token che evita di generarli a diritto, sotto si trova
+//    come l'hanno implementata
+// }
+
 export const getAccessToken = async ({ client_id, client_secret, refresh_token }: TokenAuth) => {
     const hash = getTokenHash({
         client_id,

--- a/src/token.ts
+++ b/src/token.ts
@@ -119,7 +119,7 @@ export const getAccessTokenByServiceAccount = async (service_account: ServiceAcc
     const token_promise = requestAccessTokenByServiceAccount(v).then(token => {
         return {
             access_token: token.access_token,
-            expires_in: now + token.expires_in,
+            expires_in: now + (token.expires_in * 1000),
         }
     })
     .catch(e => {

--- a/src/token.ts
+++ b/src/token.ts
@@ -6,6 +6,7 @@ const ADWORDS_AUTH_SERVICE_ACCOUNTURL = 'https://oauth2.googleapis.com/token'
 
 import { cached_tokens, unresolved_token_promises } from './token_cache'
 import {KJUR} from "jsrsasign";
+import {ServiceAccount} from "./client";
 
 interface TokenAuth {
     client_id: string
@@ -91,7 +92,7 @@ const refreshAccessToken = (client_id: string, client_secret: string, refresh_to
     })
 }
 
-export const getAccessTokenByServiceAccount = async (service_account: any) => {
+export const getAccessTokenByServiceAccount = async (service_account: ServiceAccount, sub: string) => {
 
     const jwtHeader = {
         alg: "RS256",
@@ -100,7 +101,7 @@ export const getAccessTokenByServiceAccount = async (service_account: any) => {
     const todayEpoch = parseInt(String(Date.now() / 1000));
     const jwtClaimSet = {
         iss: service_account.client_email,
-        sub: service_account.sub,
+        sub: sub,
         scope: "https://www.googleapis.com/auth/adwords",
         aud: service_account.token_uri,
         exp: todayEpoch + (60 * 10),

--- a/src/token.ts
+++ b/src/token.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto'
 import request from 'request'
 
 const ADWORDS_AUTH_URL = 'https://accounts.google.com/o/oauth2/token'
-const ADWORDS_AUTH_SERVICE_ACCOUNTURL = 'https://oauth2.googleapis.com/token'
+const ADWORDS_AUTH_SERVICE_ACCOUNT_URL = 'https://oauth2.googleapis.com/token'
 
 import { cached_tokens, unresolved_token_promises } from './token_cache'
 import {KJUR} from "jsrsasign";
@@ -131,7 +131,7 @@ export const getAccessTokenByServiceAccount = async (service_account: ServiceAcc
 
 const requestAccessTokenByServiceAccount = (assertion: string): Promise<TokenReturn> => {
     const options = {
-        url: ADWORDS_AUTH_SERVICE_ACCOUNTURL,
+        url: ADWORDS_AUTH_SERVICE_ACCOUNT_URL,
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/token.ts
+++ b/src/token.ts
@@ -6,7 +6,7 @@ const ADWORDS_AUTH_SERVICE_ACCOUNT_URL = 'https://oauth2.googleapis.com/token'
 
 import { cached_tokens, unresolved_token_promises } from './token_cache'
 import {KJUR} from "jsrsasign";
-import {ServiceAccount} from "./client";
+import {ServiceAccount} from "./types";
 
 interface TokenAuth {
     client_id: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -326,3 +326,11 @@ interface CreateCustomerFlowSettingsWithCustomer {
 export type CreateCustomerFlowSettings =
     | CreateCustomerFlowSettingsWithoutCustomer
     | CreateCustomerFlowSettingsWithCustomer
+
+export interface ServiceAccount {
+    readonly private_key: string
+    readonly auth_uri: string
+    readonly token_uri: string
+    readonly client_email: string
+    readonly sub: string
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,5 +332,4 @@ export interface ServiceAccount {
     readonly auth_uri: string
     readonly token_uri: string
     readonly client_email: string
-    readonly sub: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,6 +430,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/jsrsasign@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-8.0.2.tgz#39f19045f33a7e2bd09a195556c1450d2e82f4c9"
+  integrity sha512-H9E1AhOgouH0Zi7O1TAfntNXzMgFZWncB0MY/bfVs4v4gUBVsEM/ZCjBqPmw3QfsL2ZdcBb7YunXykMLpqNBhQ==
+
 "@types/lodash.camelcase@^4.3.6":
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.camelcase/-/lodash.camelcase-4.3.6.tgz#393c748b70cd926fc629e6502a9d0929f217d5fd"
@@ -3048,6 +3053,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsrsasign@^8.0.15:
+  version "8.0.15"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.15.tgz#0d56856efa75fad84b578655249700f500388112"
+  integrity sha512-6UKHqnNs5lYROn03wf1BTw7DQx5tW616DTigjbo0JHV97D3HzIqYmPVCBSNsfEfQOrfpFqmPZJvaC3cMNOT0Yw==
 
 jwa@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

We introduce support for service accounts!!

*   **What is the current behavior?** (You can also link to an open issue here)

Service account isn't supported
https://github.com/Opteo/google-ads-api/issues/83
https://github.com/Opteo/google-ads-api/issues/44
https://github.com/Opteo/google-ads-api/issues/169

-   **What is the new behavior (if this is a feature change)?**

Will be possible to create a Google Ads Client that use a service account private key to do auth and then operate behind an authorized Google Ads real user (sub).

```
const service_account_data = JSON.parse('your service account JSON file contents')

const options = {
    developer_token: 'your developer token',
    client_id: service_account_data.client_id,
    client_secret: ''
}
    
const service_account = {
    private_key: service_account_data.private_key,
    auth_uri: service_account_data.auth_uri,
    token_uri: service_account_data.token_uri,
    client_email: service_account_data.client_email
};
    
const sub = 'your email that the service account will impersonate';
    
client = new GoogleAdsApi(options)
await client.requestAndSetAccessToken(service_account, sub);
```

*   **Other information**:

Many thanks to @ice1829!!