### PR TITLE
fix: summary row and result count report options

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,37 @@ const adGroupAd = new resources.AdGroupAd({
 const { results } = await cus.adGroupAds.create([adGroupAd]);
 ```
 
+## Summary Row
+
+If a summary row is requested in the `report` method, it will be included as the **first** row of the results.
+
+```ts
+const [summaryRow, ...response] = await customer.report({
+  entity: "campaign",
+  metrics: ["metrics.clicks", "metrics.all_conversions"],
+});
+```
+
+If a summery row is requested in the `reportStream` method, it will be included as the **final** iterated row of the results.
+
+```ts
+const stream = customer.reportStream({
+  entity: "campaign",
+  metrics: ["metrics.clicks", "metrics.all_conversions"],
+});
+
+const accumulator = [];
+for await (const row of stream) {
+  accumulator.push(row);
+}
+
+const summaryRow = accumulator.slice(-1)[0];
+```
+
+## Total Results Count
+
+The `reportCount` method acts like `report` but returns the total number of rows that the query would have returned (ignoring the limit). This replaces the `return_total_results_count` report option.
+
 ## Resource Names
 
 The library provides a set of helper methods under the `ResourceNames` export. These are used for compiling resource names from ids. Arguments can be of the type `string`, `number`, or a mix of both. If you have a `client.Customer` instance available, you can get the customer id with `customer.credentials.customerId`.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ For now we recommend following the usage examples below.
   - [Retrieve Campaigns using GAQL](#retrieve-campaigns-using-gaql)
   - [Retrieve Ad Group metrics by date](#retrieve-ad-group-metrics-by-date)
   - [Retrieve Keywords with streaming](#retrieve-keywords-with-streaming)
+  - [Summary Row](#summary-row)
+  - [Total Results Count](#total-results-count)
 - Mutations
   - [Create an expanded text ad](#create-an-expanded-text-ad)
 - Misc
@@ -250,6 +252,7 @@ If a summary row is requested in the `report` method, it will be included as the
 const [summaryRow, ...response] = await customer.report({
   entity: "campaign",
   metrics: ["metrics.clicks", "metrics.all_conversions"],
+  summary_row_setting: enums.SummaryRowSetting.SUMMARY_ROW_WITH_RESULTS,
 });
 ```
 
@@ -259,6 +262,7 @@ If a summery row is requested in the `reportStream` method, it will be included 
 const stream = customer.reportStream({
   entity: "campaign",
   metrics: ["metrics.clicks", "metrics.all_conversions"],
+  summary_row_setting: enums.SummaryRowSetting.SUMMARY_ROW_WITH_RESULTS,
 });
 
 const accumulator = [];
@@ -272,6 +276,13 @@ const summaryRow = accumulator.slice(-1)[0];
 ## Total Results Count
 
 The `reportCount` method acts like `report` but returns the total number of rows that the query would have returned (ignoring the limit). This replaces the `return_total_results_count` report option.
+
+```ts
+const totalRows = await customer.reportCount({
+  entity: "search_term_view",
+  attributes: ["search_term_view.resource_name"],
+})
+```
 
 ## Resource Names
 

--- a/src/query.spec.ts
+++ b/src/query.spec.ts
@@ -44,7 +44,6 @@ const options: ReportOptions = {
   page_size: 5,
   page_token: "A1B2C3D4",
   validate_only: false,
-  return_total_results_count: false,
   summary_row_setting: "NO_SUMMARY_ROW",
 };
 
@@ -588,7 +587,6 @@ const expectedRequestOptions = {
   page_size: 5,
   page_token: "A1B2C3D4",
   validate_only: false,
-  return_total_results_count: false,
   summary_row_setting: "NO_SUMMARY_ROW",
 };
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -326,17 +326,10 @@ export function buildRequestOptions(
     page_size,
     page_token,
     validate_only,
-    return_total_results_count,
     summary_row_setting,
   } = reportOptions;
 
-  return {
-    page_size,
-    page_token,
-    validate_only,
-    return_total_results_count,
-    summary_row_setting,
-  };
+  return { page_size, page_token, validate_only, summary_row_setting };
 }
 
 export function buildQuery(

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,10 +1,9 @@
+import { Readable } from "stream";
 import { Customer } from "./customer";
 import { Hooks } from "./hooks";
 import * as parser from "./parser";
+import { errors, GoogleAdsServiceClient, services } from "./protos";
 import { PageToken } from "./types";
-import { GoogleAdsServiceClient, services, errors } from "./protos";
-
-import { Readable } from "stream";
 
 export const MOCK_CLIENT_ID = "MOCK CLIENT ID";
 export const MOCK_CLIENT_SECRET = "MOCK CLIENT SECRET";
@@ -13,11 +12,17 @@ export const MOCK_REFRESH_TOKEN = "MOCK REFRESH TOKEN";
 export const MOCK_CID = "MOCK CID";
 export const MOCK_LOGIN_CID = "MOCK LOGIN CID";
 
+export const mockGaqlQuery = "SELECT campaign.id FROM campaign";
+
 export const mockQueryReturnValue: services.IGoogleAdsRow[] = [
   { campaign: { resource_name: "customers/1/campaigns/11" } },
   { campaign: { resource_name: "customers/2/campaigns/22" } },
   { campaign: { resource_name: "customers/3/campaigns/33" } },
 ];
+
+export const mockSummaryRow: services.IGoogleAdsRow = {
+  metrics: { clicks: 90, impressions: 153 },
+};
 
 export const mockMutationReturnValue: services.MutateGoogleAdsResponse = {
   mutate_operation_responses: [],
@@ -77,6 +82,7 @@ export function mockBuildSearchStreamRequestAndService(
 ): {
   spyBuild: jest.SpyInstance;
   mockStreamData: (data: services.IGoogleAdsRow[]) => void;
+  mockStreamSummaryRow: () => void;
   mockStreamError: (error: Error) => void;
   mockStreamEnd: () => void;
 } {
@@ -84,6 +90,13 @@ export function mockBuildSearchStreamRequestAndService(
 
   const mockStreamData = (results: services.IGoogleAdsRow[]) => {
     const chunk = { results } as services.SearchGoogleAdsStreamResponse;
+    mockStream.push(chunk);
+  };
+
+  const mockStreamSummaryRow = () => {
+    const chunk = {
+      summary_row: mockSummaryRow,
+    } as services.SearchGoogleAdsStreamResponse;
     mockStream.push(chunk);
   };
 
@@ -111,27 +124,36 @@ export function mockBuildSearchStreamRequestAndService(
   return {
     spyBuild,
     mockStreamData,
+    mockStreamSummaryRow,
     mockStreamError,
     mockStreamEnd,
   };
 }
 
-export function mockBuildSearchRequestAndService(
-  customer: Customer,
-  shouldThrow = false
-): { mockService: GoogleAdsServiceClient; spyBuild: jest.SpyInstance } {
+export function mockBuildSearchRequestAndService({
+  customer,
+  shouldThrow = false,
+  includeSummaryRow = false,
+}: {
+  customer: Customer;
+  shouldThrow?: boolean;
+  includeSummaryRow?: boolean;
+}): { mockService: GoogleAdsServiceClient; spyBuild: jest.SpyInstance } {
   const mockService = ({
-    search: () => {
+    search: (): [
+      services.IGoogleAdsRow[],
+      null,
+      services.ISearchGoogleAdsResponse
+    ] => {
       if (shouldThrow) {
         throw new Error(mockErrorMessage);
       }
-      return [mockQueryReturnValue];
-    },
-    searchAsync: () => {
-      if (shouldThrow) {
-        throw new Error(mockErrorMessage);
-      }
-      return mockQueryReturnValue;
+
+      const searchGoogleAdsResponse = includeSummaryRow
+        ? { summary_row: mockSummaryRow }
+        : {};
+
+      return [mockQueryReturnValue, null, searchGoogleAdsResponse];
     },
   } as unknown) as GoogleAdsServiceClient;
 
@@ -149,12 +171,17 @@ export function mockBuildSearchRequestAndService(
   return { mockService, spyBuild };
 }
 
-export function mockBuildMutateRequestAndService(
-  customer: Customer,
+export function mockBuildMutateRequestAndService({
+  customer,
   shouldThrow = false,
-  request?: services.MutateGoogleAdsRequest,
-  response?: services.MutateGoogleAdsResponse
-): { mockService: services.GoogleAdsService; spyBuild: jest.SpyInstance } {
+  request,
+  response,
+}: {
+  customer: Customer;
+  shouldThrow?: boolean;
+  request?: services.MutateGoogleAdsRequest;
+  response?: services.MutateGoogleAdsResponse;
+}): { mockService: services.GoogleAdsService; spyBuild: jest.SpyInstance } {
   const mockService = ({
     mutate() {
       if (shouldThrow) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,7 @@ export type Constraints = Constraint[] | ConstraintType2;
 // Common request options used for the report/query methods
 export type RequestOptions = Omit<
   services.ISearchGoogleAdsRequest,
-  "customer_id" | "query"
+  "customer_id" | "query" | "return_total_results_count"
 >;
 
 export type MutateOptions = Omit<


### PR DESCRIPTION
 - Summary row field working for `report`. If getting summary row and data, then the summary will be the **first** row of the returned data.
 - Summary row field working for `reportStream`. If getting summary row and data then the summary will be the **last** iterated row.
 - Result count using a new function `reportCount` that acts like `report` but returns a number representing the number of rows in the query.