### PR TITLE
fix: parser error when field is not present

### DIFF
--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -210,6 +210,30 @@ describe("parseRows", () => {
       },
     ]);
   });
+
+  it("handles missing data", () => {
+    const fields = [
+      "ad_group_criterion.resource_name",
+      "ad_group_criterion.listing_group.case_value.product_type.level",
+    ];
+    const rows: services.IGoogleAdsRow[] = [
+      {
+        ad_group: null,
+        ad_group_criterion: {
+          resource_name: "customers/123/adGroupCriteria/123~123",
+          // Some fields (such as listing_group) are missing if not applicable for the resource
+        },
+      },
+    ];
+    expect(parseRows(rows, fields)).toEqual([
+      {
+        ad_group_criterion: {
+          resource_name: rows[0]?.ad_group_criterion?.resource_name,
+          listing_group: null,
+        },
+      },
+    ]);
+  });
 });
 
 describe("getGAQLFields", () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,6 +121,7 @@ function parseNestedValues(
   field: string,
   paths: string[]
 ) {
+  if (!data) return null;
   const [parentField, ...childFields] = paths;
   if (!row) row = {};
   if (childFields.length === 0) {


### PR DESCRIPTION
In the raw response from Google sometimes fields are simply not present rather than being set to `null`. This fix ensures the parser doesn't crash if this happens, and sets the field to `null` if it doesn't exist.

Thanks to @loicadolphe for discovering this.