### PR TITLE
feat: order report option for multiple order by and sort orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,38 @@ The `reportCount` method acts like `report` but returns the total number of rows
 const totalRows = await customer.reportCount({
   entity: "search_term_view",
   attributes: ["search_term_view.resource_name"],
-})
+});
+```
+
+## Report Results Order
+
+There are 2 methods of sorting the results of report. The prefered method is to use the `order` key, which should be an array of objects with a `field` key and an optional `sort_order` key. The order of the items in the array will map to the order of the sorting keys in the GAQL query, and hence the priorities of the sorts.
+
+```ts
+const response = await customer.report({
+  entity: "campaign",
+  attributes: ["campaign.id"],
+  metrics: ["metrics.clicks"],
+  segments: ["segments.date"],
+  order: [
+    { field: "metrics.clicks", sort_order: "DESC" },
+    { field: "segments.date", sort_order: "ASC" },
+    { field: "campaign.id" }, // default sort_order is descending
+  ],
+});
+```
+
+The other method is to use the `order_by` and `sort_order` keys, however this will be depricated in a future version of the API.
+
+```ts
+const response = await customer.report({
+  entity: "campaign",
+  attributes: ["campaign.id"],
+  metrics: ["metrics.clicks"],
+  segments: ["segments.date"],
+  order_by: "metrics.clicks",
+  sort_order: "DESC",
+});
 ```
 
 ## Resource Names

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ const response = await customer.report({
 });
 ```
 
-The other method is to use the `order_by` and `sort_order` keys, however this will be depricated in a future version of the API.
+The other method is to use the `order_by` and `sort_order` keys, however this will be deprecated in a future version of the API.
 
 ```ts
 const response = await customer.report({

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,14 @@ export interface ReportOptions extends RequestOptions {
   segments?: fields.Segments;
   constraints?: Constraints;
   limit?: number;
+  order?: Order[];
+  /**
+   * @deprecated `order_by` will be removed in a future version. Migration to the `order` report option key is advised.
+   */
   order_by?: ConstraintKey | ConstraintKey[];
+  /**
+   * @deprecated `sort_order` will be removed in a future version. Migration to the `order` report option key is advised.
+   */
   sort_order?: SortOrder;
   date_constant?: DateConstant;
   from_date?: string;
@@ -41,6 +48,11 @@ export type DateConstant =
   | "LAST_WEEK_MON_SUN";
 
 export type SortOrder = "ASC" | "DESC";
+
+export interface Order {
+  field: ConstraintKey;
+  sort_order?: SortOrder;
+}
 
 export type ConstraintKey = fields.Attribute | fields.Metric | fields.Segment;
 export type ConstraintValue = number | string | boolean | (number | string)[];


### PR DESCRIPTION
This PR deprecates the `order_by` and `sort_order` report options in favour of a new key `order`. The `order` key takes an array of objects, each having a `field` key for an attribute, metric or segment, and an optional `sort_order` key. If no sort order is provided then the default sort order is `DESC`. The order of the items in the `order` array will match to the order of the order by clauses in the GAQL query.

The `order_by` and `sort_order` report options will still remain available for the time being, with plans to remove them in a future version.

e.g.
```ts
const response = await customer.report({
  entity: "campaign",
  attributes: ["campaign.id"],
  metrics: ["metrics.clicks", "metrics.impressions"],
  order: [
    { field: "metrics.clicks", sort_order: "DESC" },
    { field: "metrics.impressions", sort_order: "ASC" },
    { field: "campaign.id" },
  ]
})
```
will result in a GAQL query of:
```SQL
SELECT
  campaign.id,
  metrics.clicks,
  metrics.impressions
FROM
  campaign
ORDER BY
  metrics.clicks DESC,
  metrics.impressions ASC,
  campaign.id DESC
```