### PR TITLE
fix: fixed parser breaking for multi line queries

### DIFF
--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -250,6 +250,25 @@ describe("getGAQLFields", () => {
     expect(getGAQLFields(gaqlQuery).sort()).toEqual(fields.sort());
   });
 
+  it("handles multi-line gaql queries", () => {
+    const gaqlQuery = `
+      SELECT
+        campaign.resource_name,
+        campaign.name,
+        metrics.clicks,
+        segments.date
+      FROM
+        campaign`;
+    const fields = [
+      "campaign.resource_name",
+      "campaign.name",
+      "metrics.clicks",
+      "segments.date",
+    ];
+
+    expect(getGAQLFields(gaqlQuery).sort()).toEqual(fields.sort());
+  });
+
   it("throws if the query contains no fields", () => {
     const gaqlQuery = "SELECT FROM campaign";
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -54,7 +54,7 @@ export function getGAQLFields(gaqlString: string): string[] {
 
   const fields = normalisedQuery
     .toLowerCase()
-    .replace(/(select)|(from.*)|(\s+)/g, "")
+    .replace(/(.*select)|(from.*)|(\s+)/g, "")
     .split(",")
     .filter((field) => field.length > 0);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,7 @@
 import long from "long";
 import { ReportOptions } from "./types";
 import { services, fields } from "./protos";
+import { normaliseQuery } from "./utils";
 
 export const ParsingError = {
   NO_REPORT_OPTIONS_OR_GAQL_QUERY:
@@ -49,9 +50,11 @@ export function parse({
 // This function assumes that a gaql query is of the format "select * * * from * ...".
 // Queries that are no in this format should have thrown an error when called.
 export function getGAQLFields(gaqlString: string): string[] {
-  const fields = gaqlString
+  const normalisedQuery = normaliseQuery(gaqlString);
+
+  const fields = normalisedQuery
     .toLowerCase()
-    .replace(/(^select)|(from.*)|(\s+)/g, "")
+    .replace(/(select)|(from.*)|(\s+)/g, "")
     .split(",")
     .filter((field) => field.length > 0);
 


### PR DESCRIPTION
As seen in #224 there is a parsing issue for multi line queries. Luckily we already have a function that is designed to normalise a multi-line query to a single line for tests. Therefore this will be a very short fix.