### PR TITLE
deps: upgraded google-ads-node to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Opteo",
   "license": "MIT",
   "dependencies": {
-    "google-ads-node": "^4.0.0",
+    "google-ads-node": "^4.0.2",
     "google-auth-library": "^6.1.3",
     "google-gax": "^2.10.2",
     "long": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,17 +1985,32 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-google-ads-node@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-4.0.0.tgz#97c35e598568598635d9e5e63b83a2b4ab7537a4"
-  integrity sha512-Pt0I8uhUizv8JkXINFZ9j3rCngTy8trY5w4oPLNepjc8kCPpXI7o930o3+oV2DqccbPk2tqrUlfqkNBPeB7OtA==
+google-ads-node@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/google-ads-node/-/google-ads-node-4.0.2.tgz#88b3ee999247f0d0945d363bd1bdadb8c47d3f5b"
+  integrity sha512-CTtB3EsRcM3LqzDg4XXeaNOkuj6g9CiwcLJB5e4aJWeobZof7yOtHOA+EWC/Gw4NwpGppHx3FqNDQONrKYy2og==
   dependencies:
-    google-gax "^2.10.2"
+    google-gax "^2.11.0"
 
 google-auth-library@^6.1.1, google-auth-library@^6.1.3:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-6.1.6.tgz#deacdcdb883d9ed6bac78bb5d79a078877fdf572"
   integrity sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==
+  dependencies:
+    arrify "^2.0.0"
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    fast-text-encoding "^1.0.0"
+    gaxios "^4.0.0"
+    gcp-metadata "^4.2.0"
+    gtoken "^5.0.4"
+    jws "^4.0.0"
+    lru-cache "^6.0.0"
+
+google-auth-library@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.0.2.tgz#cab6fc7f94ebecc97be6133d6519d9946ccf3e9d"
+  integrity sha512-vjyNZR3pDLC0u7GHLfj+Hw9tGprrJwoMwkYGqURCXYITjCrP9HprOyxVV+KekdLgATtWGuDkQG2MTh0qpUPUgg==
   dependencies:
     arrify "^2.0.0"
     base64-js "^1.3.0"
@@ -2019,6 +2034,23 @@ google-gax@^2.10.2:
     duplexify "^4.0.0"
     fast-text-encoding "^1.0.3"
     google-auth-library "^6.1.3"
+    is-stream-ended "^0.1.4"
+    node-fetch "^2.6.1"
+    protobufjs "^6.10.2"
+    retry-request "^4.0.0"
+
+google-gax@^2.11.0:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-2.11.2.tgz#9ef7773b94aaa61c4588fb2408d62e8444995026"
+  integrity sha512-PNqXv7Oi5XBMgoMWVxLZHUidfMv7cPHrDSDXqLyEd6kY6pqFnVKC8jt2T1df4JPSc2+VLPdeo6L7X9mbdQG8Xw==
+  dependencies:
+    "@grpc/grpc-js" "~1.2.0"
+    "@grpc/proto-loader" "^0.5.1"
+    "@types/long" "^4.0.0"
+    abort-controller "^3.0.0"
+    duplexify "^4.0.0"
+    fast-text-encoding "^1.0.3"
+    google-auth-library "^7.0.2"
     is-stream-ended "^0.1.4"
     node-fetch "^2.6.1"
     protobufjs "^6.10.2"


### PR DESCRIPTION
This improves performance of the client constructors by caching the proto imports.