### PR TITLE
fix: date constants are now useable as constraint values

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -5,6 +5,8 @@ import {
   ConstraintOperation,
   ConstraintType1,
   ConstraintValue,
+  DateConstant,
+  dateConstants,
   Order,
   ReportOptions,
   RequestOptions,
@@ -94,6 +96,7 @@ export function buildFromClause(entity: ReportOptions["entity"]): FromClause {
 
 export function validateConstraintKeyAndValue(
   key: ConstraintKey,
+  op: ConstraintOperation,
   val: ConstraintValue
 ): {
   op: ConstraintOperation;
@@ -104,6 +107,10 @@ export function validateConstraintKeyAndValue(
   }
 
   if (typeof val === "string") {
+    if (dateConstants.includes(val as DateConstant)) {
+      return { op, val };
+    }
+
     return {
       op: "=",
       val: new RegExp(/^'.*'$|^".*"$/g).test(val) ? val : `"${val}"`,
@@ -159,7 +166,7 @@ export function extractConstraintConditions(
           if (typeof key !== "string") {
             throw new Error(QueryError.INVALID_CONSTRAINT_KEY);
           }
-          const validatedValue = validateConstraintKeyAndValue(key, val);
+          const validatedValue = validateConstraintKeyAndValue(key, op, val);
           // @ts-ignore
           return `${key} ${op} ${validatedValue.val}` as const;
         } else if (Object.keys(con).length === 1) {
@@ -167,6 +174,7 @@ export function extractConstraintConditions(
 
           const validatedValue = validateConstraintKeyAndValue(
             key as ConstraintKey,
+            "=",
             val as ConstraintValue
           );
 
@@ -184,6 +192,7 @@ export function extractConstraintConditions(
     return Object.entries(constraints).map(([key, val]) => {
       const validatedValue = validateConstraintKeyAndValue(
         key as ConstraintKey,
+        "=",
         val as ConstraintValue
       );
 
@@ -399,6 +408,8 @@ export function buildQuery(
     reportOptions.entity
   );
   const requestOptions: RequestOptions = buildRequestOptions(reportOptions);
+
+  console.log(`${SELECT}${FROM}${WHERE}${ORDER}${LIMIT}`);
 
   return {
     gaqlQuery: `${SELECT}${FROM}${WHERE}${ORDER}${LIMIT}`,

--- a/src/query.ts
+++ b/src/query.ts
@@ -409,8 +409,6 @@ export function buildQuery(
   );
   const requestOptions: RequestOptions = buildRequestOptions(reportOptions);
 
-  console.log(`${SELECT}${FROM}${WHERE}${ORDER}${LIMIT}`);
-
   return {
     gaqlQuery: `${SELECT}${FROM}${WHERE}${ORDER}${LIMIT}`,
     requestOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,21 @@ export type DateConstant =
   | "LAST_WEEK_SUN_SAT"
   | "LAST_WEEK_MON_SUN";
 
+export const dateConstants: DateConstant[] = [
+  "TODAY",
+  "YESTERDAY",
+  "LAST_7_DAYS",
+  "LAST_BUSINESS_WEEK",
+  "THIS_MONTH",
+  "LAST_MONTH",
+  "LAST_14_DAYS",
+  "LAST_30_DAYS",
+  "THIS_WEEK_SUN_TODAY",
+  "THIS_WEEK_MON_TODAY",
+  "LAST_WEEK_SUN_SAT",
+  "LAST_WEEK_MON_SUN",
+];
+
 export type SortOrder = "ASC" | "DESC";
 
 export interface Order {


### PR DESCRIPTION
This PR allows date constants to be used as a constraint value without wrapping them in quotation marks (which breaks them)