### PR TITLE
feat: raw report stream customer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ for await (const row of stream) {
 
 ## Retrieve Keywords with a raw stream
 
-Returns the raw stream so that events can be handled manually. This is the recommended method of retrieving data with over 10,000 rows. For more information on Google's stream methods please [consult their docs](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming).
+Returns the raw stream so that events can be handled manually. For more information on Google's stream methods please [consult their docs](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#server-streaming).
 
 <!-- prettier-ignore-start -->
 

--- a/README.md
+++ b/README.md
@@ -434,8 +434,8 @@ These hooks also have access to the `method` argument, containing the mutation m
 
 ### Pre-request hooks:
 
-- `onQueryStart`
-- `onStreamStart`
+- `onQueryStart` - `query` and `report`
+- `onStreamStart` - `reportStream` and `reportStreamRaw`
 - `onMutationStart`
 
 These hooks are executed **before** a query/stream/mutation.
@@ -465,11 +465,11 @@ const customer = client.Customer({
 
 ### On error hooks:
 
-- `onQueryError`
-- `onStreamError`
+- `onQueryError` - `query` and `report`
+- `onStreamError` - `reportStream` (but **not** `reportStreamRaw`)
 - `onMutationError`
 
-These hooks are executed when a query/stream/mutation throws an error. If there error is a Google Ads failure then it will be converted to a `GoogleAdsFailure` first. The error can be accessed in these hooks with the `error` argument.
+These hooks are executed when a query/stream/mutation throws an error. If there error is a Google Ads failure then it will be converted to a `GoogleAdsFailure` first. The error can be accessed in these hooks with the `error` argument. Note that the `onStreamError` hook will not work with the `reportStreamRaw` method to avoid blocking the thread.
 
 ```ts
 import { OnQueryError } from "google-ads-api";
@@ -487,7 +487,7 @@ const customer = client.Customer({
 
 ### Post-request hooks:
 
-- `onQueryEnd`
+- `onQueryEnd` - `query` and `report`
 - `onMutationEnd`
 
 These hooks are executed **after** a query or mutation. This library does not contain an `onStreamEnd` hook to avoid accumulating the results of streams, and also so that we don't block the thread by waiting for the end event to be emitted.

--- a/src/customer.spec.ts
+++ b/src/customer.spec.ts
@@ -548,6 +548,7 @@ describe("reportStream", () => {
     const alternativeReturnValue = "return this instead";
     const hooks: Hooks = {
       onStreamStart({ cancel }) {
+        // @ts-expect-error should not be passing an alternate value to onStreamStart
         cancel(alternativeReturnValue);
       },
     };

--- a/src/customer.spec.ts
+++ b/src/customer.spec.ts
@@ -687,39 +687,109 @@ describe("reportStreamRaw", () => {
   afterEach(() => jest.resetAllMocks());
 
   it("does not parse any results", async () => {
-    // TODO:
+    const customer = newCustomer({});
+    const {
+      mockStreamData,
+      mockStreamEnd,
+    } = mockBuildSearchStreamRequestAndService(customer);
+    const mockedParse = mockParse(mockParsedValues);
+    await customer.reportStreamRaw(mockReportOptions);
+    mockStreamData(mockQueryReturnValue);
+    mockStreamEnd();
+
+    expect(mockedParse).not.toHaveBeenCalled();
   });
 
   it("calls onStreamStart when provided", async () => {
-    // TODO:
+    const hooks: Hooks = {
+      onStreamStart() {
+        return;
+      },
+    };
+    const customer = newCustomer(hooks);
+    const {
+      mockStreamData,
+      mockStreamEnd,
+    } = mockBuildSearchStreamRequestAndService(customer);
+    const spyHook = jest.spyOn(hooks, "onStreamStart");
+    await customer.reportStreamRaw(mockReportOptions);
+    mockStreamData(mockQueryReturnValue);
+    mockStreamEnd();
+
+    expect(spyHook).toHaveBeenCalled();
+    expect(spyHook).toHaveBeenCalledWith({
+      credentials: expect.any(Object),
+      query: expect.any(String),
+      reportOptions: mockReportOptions,
+      cancel: expect.any(Function),
+      editOptions: expect.any(Function),
+    });
   });
 
   it("calls onStreamStart asynchronously", async () => {
-    // TODO:
+    const container = mockMethod();
+    const spyMockMethod = jest.spyOn(container, "method");
+    const hooks: Hooks = {
+      async onStreamStart() {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        container.method();
+      },
+    };
+    const customer = newCustomer(hooks);
+    const {
+      mockStreamData,
+      mockStreamEnd,
+    } = mockBuildSearchStreamRequestAndService(customer);
+    await customer.reportStreamRaw(mockReportOptions);
+    mockStreamData(mockQueryReturnValue);
+    mockStreamEnd();
+
+    expect(spyMockMethod).toHaveBeenCalled();
   });
 
   it("cancels the query when cancel() is called in onStreamStart", async () => {
-    // TODO:
-  });
+    const hooks: Hooks = {
+      onStreamStart({ cancel }) {
+        cancel();
+      },
+    };
+    const customer = newCustomer(hooks);
+    const { spyBuild } = mockBuildSearchStreamRequestAndService(customer);
+    const stream = await customer.reportStreamRaw(mockReportOptions);
 
-  it("does NOT return the argument of cancel() if one is provided in onStreamStart", async () => {
-    // TODO:
+    expect(stream).not.toBeDefined();
+    expect(spyBuild).not.toHaveBeenCalled();
   });
 
   it("edits the requestOptions when editOptions() is called in onStreamStart", async () => {
-    // TODO:
-  });
+    const hooks: Hooks = {
+      onStreamStart({ editOptions }) {
+        editOptions({ validate_only: true, page_size: 4 });
+      },
+    };
+    const customer = newCustomer(hooks);
+    const {
+      spyBuild,
+      mockStreamData,
+      mockStreamEnd,
+    } = mockBuildSearchStreamRequestAndService(customer);
+    const requestOptions: RequestOptions = {
+      validate_only: false, // changed
+      page_token: "abcd",
+      page_size: 2, // changed
+    };
+    await customer.reportStreamRaw({
+      ...mockReportOptions,
+      ...requestOptions,
+    });
+    mockStreamData(mockQueryReturnValue);
+    mockStreamEnd();
 
-  it("calls onStreamError when provided and when the stream throws an error", async () => {
-    // TODO:
-  });
-
-  it("calls onStreamError asynchronously", async () => {
-    // TODO:
-  });
-
-  it("does not call onStreamError when provided but when the query does not throw an error", async () => {
-    // TODO:
+    expect(spyBuild).toHaveBeenCalledWith(mockGaqlQuery, {
+      validate_only: true,
+      page_token: "abcd",
+      page_size: 4,
+    });
   });
 });
 

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -299,7 +299,7 @@ export class Customer extends ServiceFactory {
   }> {
     const response: services.IGoogleAdsRow[] = [];
     let nextPageToken: PageToken = undefined;
-    let i = 1;
+    let i = 1; // TODO: remove logging
     const initialSearch = await this.search(gaqlQuery, requestOptions);
     const totalResultsCount = initialSearch.totalResultsCount;
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,7 @@ import {
   MutateOptions,
 } from "./types";
 
-export type BaseQueryHookArgs = {
+export type BaseRequestHookArgs = {
   credentials: CustomerCredentials;
   query: string;
   reportOptions?: ReportOptions;
@@ -41,15 +41,15 @@ type PostHookArgs<
 
 type HookArgs = PreHookArgs | ErrorHookArgs | PostHookArgs;
 
-type QueryHook<H extends HookArgs> = (args: BaseQueryHookArgs & H) => void;
+type RequestHook<H extends HookArgs> = (args: BaseRequestHookArgs & H) => void;
 
 type MutationHook<H extends HookArgs> = (
   args: BaseMutationHookArgs & H
 ) => void;
 
-export type OnQueryStart = QueryHook<PreHookArgs<RequestOptions>>;
-export type OnQueryError = QueryHook<ErrorHookArgs>;
-export type OnQueryEnd = QueryHook<PostHookArgs<services.IGoogleAdsRow[]>>;
+export type OnRequestStart = RequestHook<PreHookArgs<RequestOptions>>;
+export type OnRequestError = RequestHook<ErrorHookArgs>;
+export type OnRequestEnd = RequestHook<PostHookArgs<services.IGoogleAdsRow[]>>;
 
 export type OnMutationStart = MutationHook<PreHookArgs<MutateOptions>>;
 export type OnMutationError = MutationHook<ErrorHookArgs>;
@@ -67,7 +67,7 @@ export interface Hooks {
    * @param cancel utility function for cancelling the query. if an argument is provided then the query will return this argument
    * @param editOptions utility function for editing the request options. any request option keys that are passed will be changed
    */
-  onQueryStart?: OnQueryStart;
+  onQueryStart?: OnRequestStart;
   /**
    * @description Hook called upon a query throwing an error
    * @params `{ credentials, query, reportOptions, error }`
@@ -76,7 +76,7 @@ export interface Hooks {
    * @param reportOptions
    * @param error google ads error
    */
-  onQueryError?: OnQueryError;
+  onQueryError?: OnRequestError;
   /**
    * @description Hook called after successful execution of a query
    * @params `{ credentials, query, reportOptions, response, resolve }`
@@ -86,7 +86,26 @@ export interface Hooks {
    * @param response results of the query, not available on reportStream
    * @param resolve utility function for returning an alternative value from the query. will not work with reportStream
    */
-  onQueryEnd?: OnQueryEnd;
+  onQueryEnd?: OnRequestEnd;
+  /**
+   * @description Hook called before execution of a stream.
+   * @params `{ credentials, query, reportOptions, cancel, editOptions }`
+   * @param credentials customer id, login customer id, linked customer id
+   * @param query gaql
+   * @param reportOptions
+   * @param cancel utility function for cancelling the stream
+   * @param editOptions utility function for editing the request options. any request option keys that are passed will be changed
+   */
+  onStreamStart?: OnRequestStart;
+  /**
+   * @description Hook called upon a stream throwing an error
+   * @params `{ credentials, query, reportOptions, error }`
+   * @param credentials customer id, login customer id, linked customer id
+   * @param query gaql
+   * @param reportOptions
+   * @param error google ads error
+   */
+  onStreamError?: OnRequestError;
   /**
    * @description Hook called before execution of a mutation.
    * @params `{ credentials, mutations, cancel, editOptions }`

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -23,8 +23,10 @@ export type BaseMutationHookArgs = {
   | { mutation: any; isServiceCall: true }
 );
 
-type PreHookArgs<T = RequestOptions | MutateOptions> = {
-  cancel: (args?: any) => void;
+type OneArgFn<A> = A extends void ? () => void : (args?: A) => void;
+
+type PreHookArgs<T = RequestOptions | MutateOptions, A = void> = {
+  cancel: OneArgFn<A>;
   editOptions: (options: Partial<T>) => void;
 };
 
@@ -47,11 +49,15 @@ type MutationHook<H extends HookArgs> = (
   args: BaseMutationHookArgs & H
 ) => void;
 
-export type OnRequestStart = RequestHook<PreHookArgs<RequestOptions>>;
+export type OnRequestStart<A = void> = RequestHook<
+  PreHookArgs<RequestOptions, A | void>
+>;
 export type OnRequestError = RequestHook<ErrorHookArgs>;
 export type OnRequestEnd = RequestHook<PostHookArgs<services.IGoogleAdsRow[]>>;
 
-export type OnMutationStart = MutationHook<PreHookArgs<MutateOptions>>;
+export type OnMutationStart<A = void> = MutationHook<
+  PreHookArgs<MutateOptions, A | void>
+>;
 export type OnMutationError = MutationHook<ErrorHookArgs>;
 export type OnMutationEnd = MutationHook<
   PostHookArgs<services.MutateGoogleAdsResponse>
@@ -64,10 +70,10 @@ export interface Hooks {
    * @param credentials customer id, login customer id, linked customer id
    * @param query gaql
    * @param reportOptions
-   * @param cancel utility function for cancelling the query. if an argument is provided then the query will return this argument
+   * @param cancel utility function for cancelling the query. if an argument is provided then the query will return this argument. however a generic type will need to be passed to `OnRequestStart` to represent the type of the alternative result.
    * @param editOptions utility function for editing the request options. any request option keys that are passed will be changed
    */
-  onQueryStart?: OnRequestStart;
+  onQueryStart?: OnRequestStart<any>;
   /**
    * @description Hook called upon a query throwing an error
    * @params `{ credentials, query, reportOptions, error }`
@@ -96,7 +102,7 @@ export interface Hooks {
    * @param cancel utility function for cancelling the stream
    * @param editOptions utility function for editing the request options. any request option keys that are passed will be changed
    */
-  onStreamStart?: OnRequestStart;
+  onStreamStart?: OnRequestStart<void>;
   /**
    * @description Hook called upon a stream throwing an error
    * @params `{ credentials, query, reportOptions, error }`
@@ -114,7 +120,7 @@ export interface Hooks {
    * @param cancel utility function for cancelling the mutation. if an argument is provided then the query/report will return this argument
    * @param editOptions utility function for editing the mutate options. any mutate option keys that are passed will be changed
    */
-  onMutationStart?: OnMutationStart;
+  onMutationStart?: OnMutationStart<any>;
   /**
    * @description Hook called upon a mutation throwing an error
    * @params `{ credentials, mutations error }`

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -98,7 +98,7 @@ export interface Hooks {
    */
   onStreamStart?: OnStreamStart;
   /**
-   * @description Hook called upon a stream throwing an error in the `reportStream` and `reportStreamRaw` methods
+   * @description Hook called upon a stream throwing an error in the `reportStream` method. Will not be called for an error in `reportStreamRaw`
    * @params `{ credentials, query, reportOptions, error }`
    * @param credentials customer id, login customer id, linked customer id
    * @param query gaql

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,11 @@ export {
 } from "./types";
 export {
   Hooks,
-  OnRequestStart,
-  OnRequestError,
-  OnRequestEnd,
+  OnQueryStart,
+  OnQueryError,
+  OnQueryEnd,
+  OnStreamStart,
+  OnStreamError,
   OnMutationStart,
   OnMutationError,
   OnMutationEnd,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,9 @@ export {
 } from "./types";
 export {
   Hooks,
-  OnQueryStart,
-  OnQueryError,
-  OnQueryEnd,
+  OnRequestStart,
+  OnRequestError,
+  OnRequestEnd,
   OnMutationStart,
   OnMutationError,
   OnMutationEnd,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
 
 // Util functions
 export { fromMicros, toMicros } from "./utils";
+export { parse } from "./parser";
 export * as ResourceNames from "./protos/autogen/resourceNames";
 
 // Util types

--- a/src/protos/autogen/serviceFactory.ts
+++ b/src/protos/autogen/serviceFactory.ts
@@ -15,9 +15,10 @@ export default class ServiceFactory extends Service {
   constructor(
     clientOptions: ClientOptions,
     customerOptions: CustomerOptions,
-    hooks?: Hooks
+    hooks?: Hooks,
+    timeout = 3600000 // 1 hour
   ) {
-    super(clientOptions, customerOptions, hooks ?? {});
+    super(clientOptions, customerOptions, hooks ?? {}, timeout);
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -31,17 +31,20 @@ export interface CallHeaders {
 export class Service {
   protected readonly clientOptions: ClientOptions;
   protected readonly customerOptions: CustomerOptions;
+  protected readonly timeout: number;
   protected readonly hooks: Hooks;
   private serviceCache!: Record<ServiceName, AllServices>;
 
   constructor(
     clientOptions: ClientOptions,
     customerOptions: CustomerOptions,
-    hooks?: Hooks
+    hooks?: Hooks,
+    timeout = 3600000 // 1 hour
   ) {
     this.clientOptions = clientOptions;
     this.customerOptions = customerOptions;
     this.hooks = hooks ?? {};
+    this.timeout = timeout;
 
     // @ts-expect-error All fields don't need to be set here
     this.serviceCache = {};


### PR DESCRIPTION
As requested in https://github.com/Opteo/google-ads-api/issues/237, this PR brings a new method `reportStreamRaw`. The new function returns the raw stream, allowing the user to handle the `data`, `error` and `end` events manually. As the data events contain un-parsed rows, this PR also exposes the `parse` function. The timeout of data retrieval functions has also been set to 1 hour (Google's recommended) from the default (1 minute) to avoid `4 DEADLINE_EXCEEDED: Deadline exceeded` errors.

There are a few breaking changes in this PR:
 - Query hooks no longer apply to the `reportStream` and `reportStreamRaw` methods. These functions now use the stream hooks `onStreamStart` (used in both) and `onStreamError` (used in `reportStream` only). There is no `onStreamEnd` hook as we want to avoid accumulating the results of streams, and also so that we don't block the thread by waiting for the `end` event to be emitted. The stream hooks also have their own types `OnStreamStart` and `OnStreamError`.
 - The `cancel` method can still be used in the `onStreamStart` hook, however it does not support an alternative result as an argument.
 - Hooks will **not** be called in the `reportCount` method to avoid cacheing conflicts. This should only be used as a utility function.