### PR TITLE
Parse rows per-page for better performance

### DIFF
--- a/src/customer.spec.ts
+++ b/src/customer.spec.ts
@@ -24,6 +24,7 @@ import {
   mockSummaryRow,
   mockTotalResultsCount,
   newCustomer,
+  noopParser,
 } from "./testUtils";
 import { MutateOptions, RequestOptions } from "./types";
 
@@ -316,7 +317,7 @@ describe("paginatedSearch", () => {
     const { response } = await customer.paginatedSearch(
       mockGaqlQuery,
       {},
-      (row) => row
+      noopParser
     );
 
     expect(response).toEqual(["a", "b", "c"]);
@@ -339,7 +340,7 @@ describe("paginatedSearch", () => {
     const { response } = await customer.paginatedSearch(
       mockGaqlQuery,
       {},
-      (row) => row
+      noopParser
     );
 
     expect(response).toEqual(["a", "b", "c", "d", "e", "f"]);
@@ -360,7 +361,7 @@ describe("paginatedSearch", () => {
     const { response } = await customer.paginatedSearch(
       mockGaqlQuery,
       {},
-      (row) => row
+      noopParser
     );
 
     expect(response).toEqual(["a", "b", "c", "d", "e", "f", "g", "h"]);
@@ -379,7 +380,7 @@ describe("paginatedSearch", () => {
     const { totalResultsCount } = await customer.paginatedSearch(
       mockGaqlQuery,
       {},
-      (row) => row
+      noopParser
     );
     expect(totalResultsCount).toEqual(mockTotalResultsCount);
   });

--- a/src/customer.ts
+++ b/src/customer.ts
@@ -327,7 +327,7 @@ export class Customer extends ServiceFactory {
     }
 
     try {
-      const _parser = (rows: services.IGoogleAdsRow[]) => {
+      const parsingWapper = (rows: services.IGoogleAdsRow[]) => {
         return this.clientOptions.disable_parsing
           ? rows
           : reportOptions
@@ -338,7 +338,7 @@ export class Customer extends ServiceFactory {
       const { response, totalResultsCount } = await this.paginatedSearch(
         gaqlQuery,
         requestOptions,
-        _parser
+        parsingWapper
       );
 
       if (this.hooks.onQueryEnd && useHooks) {

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -276,6 +276,12 @@ export function mockParse(
   return jest.spyOn(parser, "parse").mockImplementation(() => mockParsedValues);
 }
 
+export function noopParser(
+  rows: services.IGoogleAdsRow[]
+): services.IGoogleAdsRow[] {
+  return rows;
+}
+
 export function mockMethod(): {
   method(): void;
 } {

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -72,11 +72,14 @@ export function mockPaginatedSearch(
       // @ts-expect-error private method
       .spyOn(customer, "paginatedSearch")
       // @ts-expect-error
-      .mockImplementation(() => {
+      .mockImplementation((gaqlQuery, requestOptions, _parser) => {
         const totalResultsCount = includeTotalResultsCount
           ? mockTotalResultsCount
           : undefined;
-        return { response: mockQueryReturnValue, totalResultsCount };
+        return {
+          response: _parser(mockQueryReturnValue),
+          totalResultsCount,
+        };
       })
   );
 }


### PR DESCRIPTION
Today, when calling `report()`, we page though the results, then parse all the results at once. This has two drawbacks:

- For hundreds of thousands of rows, this can cause the JS event loop to be locked for longer than reasonable while parsing.
- The parser holds the whole original array in memory at once and builds up the parsed array. Towards the end of this operation, both arrays are kept in memory. This can use more RAM than necessary, and in extreme cases we've seen nodejs processes crash due to OOM errors.

This PR parses each page as it is returned from Google. 
- This means that we never parse more than `10,000` rows at a time, spreading out CPU load. 
- It also ensures that we never hold more than `20,000` rows in memory at a time in the parse() function.

Ideally we'd just use `reportStream()` for any huge datasets, but sometimes `report()` is just more convenient!