### PR TITLE
fix: round return value of toMicros

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -29,6 +29,7 @@ describe("toMicros", () => {
       [1, 1_000_000],
       [12.5, 12_500_000],
       [57742.187913, 57_742_187_913],
+      [2.05, 2_050_000],
     ];
     for (const [input, expected] of tests) {
       expect(toMicros(input)).toEqual(expected);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export function fromMicros(micros: number): number {
  * const costMicros = toMicros(12.5) // 12,500,000
  */
 export function toMicros(value: number): number {
-  return value * 1000000;
+  return Math.round(value * 1000000);
 }
 
 /**


### PR DESCRIPTION
Due to floating point shenanigans, the multiplication in `toMicros()` sometimes _adds_ decimal points. Eg:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/1063061/162949666-98cf5f0f-48e4-4f44-ba7d-d4c1539cd4ca.png">

This can cause bid mutations to fail with `Bid has too many fractional digit precision.`

In this PR, I round the result to get us back to a whole number, which micros should always be:

<img width="215" alt="image" src="https://user-images.githubusercontent.com/1063061/162950048-3d36416f-f818-477b-ac4b-56ffa26c1a59.png">

I've also added a new test, which fails without this PR.