### PR TITLE
Transpile ts to js code that suitable for Node 12

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "incremental": true /* Enable incremental compilation */,
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "es2019", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Based on https://www.npmjs.com/package/@tsconfig/node12 the target for node12 should be `es2019`.

It reduced the size from 
![image](https://user-images.githubusercontent.com/9304194/173381591-37b0a892-e83f-4299-b419-23d500bb276f.png)
to
<img width="389" alt="image" src="https://user-images.githubusercontent.com/9304194/173381644-3b617c87-84be-4bc5-83d5-c2f26aa2b042.png">
