### PR TITLE
Fix hook examples on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,9 +565,10 @@ const onQueryStart: OnQueryStart = async ({ cancel, editOptions }) => {
 
 const customer = client.Customer({
   clientOptions,
-  customerOptions,
-  hooks: { onQueryStart },
-});
+  customerOptions
+},
+  { onQueryStart }
+);
 ```
 
 ### On error hooks:
@@ -588,9 +589,10 @@ const onQueryError: OnQueryError = async ({ error }) => {
 
 const customer = client.Customer({
   clientOptions,
-  customerOptions,
-  hooks: { onQueryError },
-});
+  customerOptions
+},
+  { onQueryError }
+);
 ```
 
 ### Post-request hooks:
@@ -611,9 +613,10 @@ const onQueryEnd: OnQueryEnd = async ({ response, resolve }) => {
 
 const customer = client.Customer({
   clientOptions,
-  customerOptions,
-  hooks: { onQueryEnd },
-});
+  customerOptions
+},
+  { onQueryEnd }
+);
 ```
 
 ---


### PR DESCRIPTION
Hello!

I tinkered a little bit with the library and I found out that the hook examples in README are not following the type definitions, so those examples return a type error.

Currently, the examples include a `hook` property inside the first argument of the `Customer()` method. But such first argument follows the `CustomerOptions` interface, which doesn't have that `hooks` property.

Actually, the method `Customer()` accepts two arguments, the second one being the designated to include the hooks (following the `Hooks` interface).

This PR updates the hook examples in README to make it compliant with the library and the type definitions.

Not an expert on this library, so double-check of what I'm saying is recommended :)

Hope it helps! :raised_hands: 