### PR TITLE
fix: avoid mutating reportOptions when calling reportStream()

### DIFF
--- a/src/customer.ts
+++ b/src/customer.ts
@@ -36,7 +36,7 @@ export class Customer extends ServiceFactory {
   */
   public async query<T = services.IGoogleAdsRow[]>(
     gaqlQuery: string,
-    requestOptions: RequestOptions = {}
+    requestOptions: Readonly<RequestOptions> = {}
   ): Promise<T> {
     const { response } = await this.querier<T>(gaqlQuery, requestOptions);
     return response;
@@ -52,7 +52,7 @@ export class Customer extends ServiceFactory {
   */
   public async *queryStream<T = services.IGoogleAdsRow>(
     gaqlQuery: string,
-    requestOptions: RequestOptions = {}
+    requestOptions: Readonly<RequestOptions> = {}
   ): AsyncGenerator<T> {
     const stream = this.streamer<T>(gaqlQuery, requestOptions);
     for await (const row of stream) {
@@ -66,7 +66,7 @@ export class Customer extends ServiceFactory {
     @hooks onQueryStart, onQueryError, onQueryEnd
   */
   public async report<T = services.IGoogleAdsRow[]>(
-    options: ReportOptions
+    options: Readonly<ReportOptions>
   ): Promise<T> {
     const { gaqlQuery, requestOptions } = buildQuery(options);
     const { response } = await this.querier<T>(
@@ -82,10 +82,9 @@ export class Customer extends ServiceFactory {
     @hooks none
   */
   public async reportCount(
-    options: ReportOptions
+    options: Readonly<ReportOptions>
   ): Promise<number | undefined> {
-    options.limit = 1; // must get at least one row
-    const { gaqlQuery, requestOptions } = buildQuery(options);
+    const { gaqlQuery, requestOptions } = buildQuery({ ...options, limit: 1 }); // must get at least one row
     // @ts-expect-error we do not allow this field in reportOptions, however it is still a valid request option
     requestOptions.return_total_results_count = true;
     const useHooks = false; // to avoid cacheing conflicts
@@ -108,7 +107,7 @@ export class Customer extends ServiceFactory {
     for await (const row of stream) { ... }
   */
   public async *reportStream<T = services.IGoogleAdsRow>(
-    reportOptions: ReportOptions
+    reportOptions: Readonly<ReportOptions>
   ): AsyncGenerator<T> {
     const { gaqlQuery, requestOptions } = buildQuery(reportOptions);
     const stream = this.streamer<T>(gaqlQuery, requestOptions, reportOptions);
@@ -127,7 +126,7 @@ export class Customer extends ServiceFactory {
     stream.on('end', () => { ... })
   */
   public async reportStreamRaw(
-    reportOptions: ReportOptions
+    reportOptions: Readonly<ReportOptions>
   ): Promise<CancellableStream | void> {
     const { gaqlQuery, requestOptions } = buildQuery(reportOptions);
 
@@ -169,7 +168,7 @@ export class Customer extends ServiceFactory {
 
   private async search(
     gaqlQuery: string,
-    requestOptions: RequestOptions
+    requestOptions: Readonly<RequestOptions>
   ): Promise<{
     response: services.IGoogleAdsRow[];
     nextPageToken: PageToken;
@@ -201,7 +200,7 @@ export class Customer extends ServiceFactory {
 
   private async paginatedSearch(
     gaqlQuery: string,
-    requestOptions: RequestOptions,
+    requestOptions: Readonly<RequestOptions>,
     parser: (rows: services.IGoogleAdsRow[]) => services.IGoogleAdsRow[]
   ): Promise<{
     response: services.IGoogleAdsRow[];
@@ -229,7 +228,7 @@ export class Customer extends ServiceFactory {
   private async querier<T = services.IGoogleAdsRow[]>(
     gaqlQuery: string,
     requestOptions: RequestOptions = {},
-    reportOptions?: ReportOptions,
+    reportOptions?: Readonly<ReportOptions>,
     useHooks = true
   ): Promise<{ response: T; totalResultsCount?: number }> {
     const baseHookArguments: BaseRequestHookArgs = {
@@ -304,7 +303,7 @@ export class Customer extends ServiceFactory {
   private async *streamer<T = services.IGoogleAdsRow>(
     gaqlQuery: string,
     requestOptions: RequestOptions = {},
-    reportOptions?: ReportOptions
+    reportOptions?: Readonly<ReportOptions>
   ): AsyncGenerator<T> {
     const baseHookArguments: BaseRequestHookArgs = {
       credentials: this.credentials,

--- a/src/query.ts
+++ b/src/query.ts
@@ -157,7 +157,7 @@ export function convertNumericEnumToString(
 }
 
 export function extractConstraintConditions(
-  constraints: ReportOptions["constraints"]
+  constraints: Readonly<ReportOptions["constraints"]>
 ): ConstraintString[] {
   if (typeof constraints === "undefined") {
     return [];
@@ -254,10 +254,10 @@ export function extractDateConditions(
 }
 
 export function buildWhereClause(
-  constraints: ReportOptions["constraints"],
-  dateConstant: ReportOptions["date_constant"],
-  fromDate: ReportOptions["from_date"],
-  toDate: ReportOptions["to_date"]
+  constraints: Readonly<ReportOptions["constraints"]>,
+  dateConstant: Readonly<ReportOptions["date_constant"]>,
+  fromDate: Readonly<ReportOptions["from_date"]>,
+  toDate: Readonly<ReportOptions["to_date"]>
 ): WhereClause {
   const constraintClauses = extractConstraintConditions(constraints);
   const dateConstantClauses = extractDateConstantConditions(dateConstant);
@@ -287,7 +287,7 @@ export function buildLimitClause(limit: ReportOptions["limit"]): LimitClause {
 }
 
 export function buildParametersClause(
-  parameters: ReportOptions["parameters"]
+  parameters: Readonly<ReportOptions["parameters"]>
 ): ParametersClause {
   if (typeof parameters === "undefined") {
     return ``;
@@ -318,9 +318,9 @@ export function completeOrderly(
 }
 
 export function buildOrderClauseOld(
-  orderBy: ReportOptions["order_by"],
-  sortOrder: ReportOptions["sort_order"],
-  entity: ReportOptions["entity"]
+  orderBy: Readonly<ReportOptions["order_by"]>,
+  sortOrder: Readonly<ReportOptions["sort_order"]>,
+  entity: Readonly<ReportOptions["entity"]>
 ): OrderClause {
   if (typeof orderBy === "undefined") {
     return ``;
@@ -353,8 +353,8 @@ export function buildOrderClauseOld(
 }
 
 export function buildOrderClauseNew(
-  order: Required<ReportOptions["order"]>,
-  entity: ReportOptions["entity"]
+  order: Readonly<Required<ReportOptions["order"]>>,
+  entity: Readonly<ReportOptions["entity"]>
 ): OrderClause {
   if (!order || !Array.isArray(order)) {
     throw new Error(QueryError.INVALID_ORDER);
@@ -376,10 +376,10 @@ export function buildOrderClauseNew(
 }
 
 export function buildOrderClause(
-  order: ReportOptions["order"],
-  orderBy: ReportOptions["order_by"],
-  sortOrder: ReportOptions["sort_order"],
-  entity: ReportOptions["entity"]
+  order: Readonly<ReportOptions["order"]>,
+  orderBy: Readonly<ReportOptions["order_by"]>,
+  sortOrder: Readonly<ReportOptions["sort_order"]>,
+  entity: Readonly<ReportOptions["entity"]>
 ): OrderClause {
   if (order) {
     return buildOrderClauseNew(order, entity);
@@ -389,7 +389,7 @@ export function buildOrderClause(
 }
 
 export function buildRequestOptions(
-  reportOptions: ReportOptions
+  reportOptions: Readonly<ReportOptions>
 ): RequestOptions {
   const { page_size, page_token, validate_only, summary_row_setting } =
     reportOptions;
@@ -397,7 +397,7 @@ export function buildRequestOptions(
   return { page_size, page_token, validate_only, summary_row_setting };
 }
 
-export function buildQuery(reportOptions: ReportOptions): {
+export function buildQuery(reportOptions: Readonly<ReportOptions>): {
   gaqlQuery: Query;
   requestOptions: RequestOptions;
 } {


### PR DESCRIPTION
- Fixes an issue where calling `reportStream()` would mutate the `reportOptions` parameter's `limit`, which is an unwanted side effect.
- Sprinkled in a few `Readonly<>` wrappers around key functions to try to prevent this kind of bug in the future.