### PR TITLE
Fix recursiveFieldMaskSearch

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export function recursiveFieldMaskSearch(data: Record<string, any>): string[] {
     }
     const fieldKey = toSnakeCase(key);
     const value = data[key];
-    if (typeof value === "object" && !Array.isArray(value)) {
+    if (typeof value === "object" && !Array.isArray(value) && value !== null) {
       const children = recursiveFieldMaskSearch(value);
       for (const child of children) {
         paths.push(`${fieldKey}.${child}`);


### PR DESCRIPTION
It is currently not possible to update nullable fields to null because the `recursiveFieldMaskSearch` function fails when it tries to extract `Object.keys` from null. This behaviour is happening because `typeof null === "object"`

Here is a simple fix for that.