### PR TITLE
adding missing .query_error to err handling readme ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ try {
     // Get the first one and explicitly check for a certain error type
     const [firstError] = err.errors;
     if (
-      firstError.error_code ===
+      firstError.error_code.query_error ===
       errors.QueryErrorEnum.QueryError.UNRECOGNIZED_FIELD
     ) {
       console.log(


### PR DESCRIPTION
I've noticed when I copied and tried the error handling example in the readme, it was giving me typescript errored so figured I'd fix it. Thank you ✨ 

TypeScript error I got without the`.query_error`
```
This comparison appears to be unintentional because the types 'IErrorCode' and 'QueryError' have no overlap.
```

After the fix, no Typescript error.
