### PR TITLE
Fix: Type error for ISearchSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ export type RequestOptions = Omit<
   "customer_id" | "query" | "search_settings"
 > & {
   search_settings?: Omit<
-    services.SearchGoogleAdsRequest["search_settings"],
+    services.ISearchSettings,
     "return_total_results_count"
   >;
 };
 ```
 
 For more information please see the `SearchSettings` reference on the Google document [here](https://developers.google.com/google-ads/api/reference/rpc/v19/SearchSettings).
+
+## 19.0.1
+
+- Fix issue with type interface for search_settings not showing any valid fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ While these changes are inconvenient, the performance of the REST api is signifi
 
 To prepare for this change, we recommend you use the install the `19.0.0-rest-beta` version of this library and test your application with it.
 
+## 19.0.1
+
+- Fix issue with type interface for search_settings not showing any valid fields.
+
 ## 19.0.0
 
 ### Version Upgrade
@@ -34,7 +38,3 @@ export type RequestOptions = Omit<
 ```
 
 For more information please see the `SearchSettings` reference on the Google document [here](https://developers.google.com/google-ads/api/reference/rpc/v19/SearchSettings).
-
-## 19.0.1
-
-- Fix issue with type interface for search_settings not showing any valid fields.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-ads-api",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "Google Ads API Client Library for Node.js",
   "repository": "https://github.com/Opteo/google-ads-api",
   "main": "build/src/index.js",

--- a/src/query.spec.ts
+++ b/src/query.spec.ts
@@ -47,7 +47,7 @@ const options: ReportOptions = {
   page_token: "A1B2C3D4",
   validate_only: false,
   search_settings: {
-    return_summary_row: "NO_SUMMARY_ROW",
+    return_summary_row: false,
   },
 };
 
@@ -696,12 +696,15 @@ describe("buildOrderClauseNew", () => {
   });
 });
 
-const expectedRequestOptions = {
+const expectedRequestOptions: Pick<
+  ReportOptions,
+  "page_size" | "page_token" | "validate_only" | "search_settings"
+> = {
   page_size: 5,
   page_token: "A1B2C3D4",
   validate_only: false,
   search_settings: {
-    return_summary_row: "NO_SUMMARY_ROW",
+    return_summary_row: false,
   },
 };
 
@@ -722,7 +725,7 @@ describe("buildQuery", () => {
         ad_group.name, ad_group.id, metrics.impressions, metrics.cost_micros, segments.date
       FROM
         ad_group
-      WHERE 
+      WHERE
         ad_group.status = "PAUSED"
         AND campaign.advertising_channel_type = "SEARCH"
         AND metrics.clicks > 10

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,7 @@ export type RequestOptions = Omit<
   "customer_id" | "query" | "search_settings"
 > & {
   search_settings?: Omit<
-    services.SearchGoogleAdsRequest["search_settings"],
+    services.ISearchSettings,
     "return_total_results_count"
   >;
 };


### PR DESCRIPTION
- Fix issue with `search_settings` not showing valid fields and its broken type. This was due to the ommission not referencing the correct field with a typo of `SearchGoogleAdsRequest["search_settings"]` rather than `ISearchGoogleAdsRequest["search_settings"]`. I've used the more explicit type `ISearchSettings` just for clarity here.